### PR TITLE
Add ability to set environment variables for session process

### DIFF
--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -5,6 +5,10 @@
 # Path to the background image
 background = "/usr/share/backgrounds/greeter.jpg"
 
+# The entries defined in this section will be passed to the session as environment variables when it is started
+[env]
+ENV_VARIABLE = "value"
+
 [GTK]
 # Whether to use the dark theme
 application_prefer_dark_theme = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,11 +96,11 @@ impl GreetdClient {
     /// Schedule starting a greetd session.
     ///
     /// On success, the session will start when this greeter terminates.
-    pub fn start_session(&mut self, command: Vec<String>) -> GreetdResult {
+    pub fn start_session(&mut self, command: Vec<String>, environment: Vec<String>) -> GreetdResult {
         info!("Starting greetd session with command: {command:?}");
         let msg = Request::StartSession {
             cmd: command,
-            env: Vec::new(),
+            env: environment,
         };
         msg.write_to(&mut self.socket)?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,7 +96,11 @@ impl GreetdClient {
     /// Schedule starting a greetd session.
     ///
     /// On success, the session will start when this greeter terminates.
-    pub fn start_session(&mut self, command: Vec<String>, environment: Vec<String>) -> GreetdResult {
+    pub fn start_session(
+        &mut self,
+        command: Vec<String>,
+        environment: Vec<String>,
+    ) -> GreetdResult {
         info!("Starting greetd session with command: {command:?}");
         let msg = Request::StartSession {
             cmd: command,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,8 @@
 
 //! Configuration for the greeter
 
-use std::path::Path;
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@
 //! Configuration for the greeter
 
 use std::path::Path;
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +30,8 @@ pub struct GtkSettings {
 #[derive(Default, Deserialize, Serialize)]
 pub struct Config {
     #[serde(default)]
+    env: HashMap<String, String>,
+    #[serde(default)]
     background: Option<String>,
     #[serde(default, rename = "GTK")]
     gtk: Option<GtkSettings>,
@@ -37,6 +40,10 @@ pub struct Config {
 impl Config {
     pub fn new(path: &Path) -> Self {
         load_toml(path)
+    }
+
+    pub fn get_env(&self) -> &HashMap<String, String> {
+        &self.env
     }
 
     pub fn get_background(&self) -> &Option<String> {

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -375,7 +375,7 @@ impl Greeter {
                 return;
             };
 
-
+        // Generate env string that will be passed to greetd when starting the session
         let env = self.config.get_env();
         let mut environment = Vec::with_capacity(env.len());
         for (k, v) in env {

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -375,10 +375,16 @@ impl Greeter {
                 return;
             };
 
+
+        let env = self.config.get_env();
+        let mut environment = Vec::with_capacity(env.len());
+        for (k, v) in env {
+            environment.push(format!("{}={}", k, v));
+        }
         // Start the session.
         let response = self
             .greetd_client
-            .start_session(cmd)
+            .start_session(cmd, environment)
             .unwrap_or_else(|err| panic!("Failed to start session: {err}"));
 
         match response {


### PR DESCRIPTION
Previously, `regreet` would pass an empty vector as the environment when instructing `greetd` to start a session. This made it difficult to pass environment variables to a session.
This PR makes a small change, adding a config section called `env` that lets users define environment variables that will be passed to `greetd` when starting a session.