### PR TITLE
Improve authentication procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It is based on [Max Moser's LightDM Elephant greeter](https://github.com/max-mos
 ![Manual session entry](https://user-images.githubusercontent.com/25344287/221668422-ab82d10b-3167-4a31-9705-c1d066ced252.png)
 ![Password entry with selected user](https://user-images.githubusercontent.com/25344287/221668490-cfd231a8-bcb9-426b-ba27-783b09c29e9c.png)
 ![Password entry with manual user](https://user-images.githubusercontent.com/25344287/221668537-dbc8ebda-b1ec-4f71-a521-77674e2ee992.png)
-![Login fail](https://user-images.githubusercontent.com/25344287/221668589-191794c6-e237-497c-9efc-1d9805fd0b42.png)
+![Login fail](https://user-images.githubusercontent.com/25344287/226113001-a66e8303-6d1f-4f75-b362-baccb9e07f9f.png)
 
 These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta-theme) in dark mode with the Roboto font. All screenshots are provided under the [CC-BY-SA-4.0 license](https://creativecommons.org/licenses/by-sa/4.0/legalcode).
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -71,10 +71,10 @@ impl GreetdClient {
         Ok(resp)
     }
 
-    /// Send password to a greetd session.
-    pub fn send_password(&mut self, password: Option<String>) -> GreetdResult {
+    /// Send an auth message response to a greetd session.
+    pub fn send_auth_response(&mut self, input: Option<String>) -> GreetdResult {
         info!("Sending password to greetd");
-        let msg = Request::PostAuthMessageResponse { response: password };
+        let msg = Request::PostAuthMessageResponse { response: input };
         msg.write_to(&mut self.socket)?;
 
         let resp = Response::read_from(&mut self.socket)?;
@@ -84,7 +84,6 @@ impl GreetdClient {
             }
             Response::AuthMessage { .. } => {
                 self.auth_status = AuthStatus::InProgress;
-                unimplemented!("greetd responded with auth request after sending password.");
             }
             Response::Error { .. } => {
                 self.auth_status = AuthStatus::InProgress;

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -274,16 +274,18 @@ impl Component for Greeter {
                     connect_clicked[
                         sender,
                         secret_entry,
+                        visible_entry,
                         usernames_box,
                         username_entry,
                         sessions_box,
                         session_entry,
                     ] => move |_| {
                         sender.input(Self::Input::Login {
-                            // Here, it is sufficient to pass the text from either secret_entry or visible_entry,
-                            // because they never show at the same time and their text is synchronised through the
-                            // model.updates.input field.
-                            input: secret_entry.text().to_string(),
+                            input: match model.updates.input_mode {
+                                InputMode::Secret => secret_entry.text().to_string(),
+                                InputMode::Visible => visible_entry.text().to_string(),
+                                InputMode::None => String::new(),
+                            },
                             info: UserSessInfo::extract(
                                 &usernames_box, &username_entry, &sessions_box, &session_entry
                             ),

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -17,10 +17,9 @@ use std::thread::sleep;
 
 #[cfg(feature = "gtk4_8")]
 use crate::config::BgFit;
-use crate::gui::model::InputMode;
 
 use super::messages::{CommandMsg, InputMsg, UserSessInfo};
-use super::model::{Greeter, Updates, DEFAULT_MSG};
+use super::model::{Greeter, InputMode, Updates, DEFAULT_MSG};
 use super::templates::Ui;
 
 const DATETIME_FMT: &str = "%a %R";

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -14,7 +14,6 @@ use gtk::prelude::*;
 use relm4::{gtk, Component, ComponentParts, ComponentSender};
 use std::thread::sleep;
 
-
 #[cfg(feature = "gtk4_8")]
 use crate::config::BgFit;
 
@@ -382,5 +381,6 @@ impl Component for Greeter {
                 self.handle_greetd_response(&sender, response)
             }
         };
+        self.update_view(widgets, sender);
     }
 }

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -298,6 +298,13 @@ impl Component for Greeter {
                     }
                 },
                 #[template_child]
+                error_label {
+                    #[track(model.updates.changed(Updates::error()))]
+                    set_label: model.updates.error.as_ref().unwrap_or(&"".to_string()),
+                    #[track(model.updates.changed(Updates::error()))]
+                    set_visible: model.updates.error.is_some(),
+                },
+                #[template_child]
                 reboot_button { connect_clicked => Self::Input::Reboot },
                 #[template_child]
                 poweroff_button { connect_clicked => Self::Input::PowerOff },

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -388,7 +388,7 @@ impl Component for Greeter {
             Self::CommandOutput::UpdateTime => self
                 .updates
                 .set_time(Local::now().format(DATETIME_FMT).to_string()),
-            Self::CommandOutput::ClearErr => self.updates.set_error(None), // TODO see if this works at all
+            Self::CommandOutput::ClearErr => self.updates.set_error(None),
             Self::CommandOutput::HandleGreetdResponse(response) => {
                 self.handle_greetd_response(&sender, response)
             }

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -207,13 +207,14 @@ impl Component for Greeter {
                     #[track(model.updates.changed(Updates::input_prompt()))]
                     set_label: &model.updates.input_prompt,
                 },
+                // FIXME focus of input field is messed up
                 #[template_child]
                 secret_entry {
                     #[track(model.updates.changed(Updates::input_mode()))]
                     set_visible: model.updates.input_mode == InputMode::Secret,
                     #[track(
                         model.updates.changed(Updates::input_mode())
-                        && model.updates.is_input()
+                        && model.updates.input_mode == InputMode::Secret
                     )]
                     grab_focus: (),
                     #[track(model.updates.changed(Updates::input()))]
@@ -235,7 +236,7 @@ impl Component for Greeter {
                     set_visible: model.updates.input_mode == InputMode::Visible,
                     #[track(
                         model.updates.changed(Updates::input_mode())
-                        && model.updates.is_input()
+                        && model.updates.input_mode == InputMode::Visible
                     )]
                     grab_focus: (),
                     #[track(model.updates.changed(Updates::input()))]

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -207,7 +207,6 @@ impl Component for Greeter {
                     #[track(model.updates.changed(Updates::input_prompt()))]
                     set_label: &model.updates.input_prompt,
                 },
-                // FIXME focus of input field is messed up
                 #[template_child]
                 secret_entry {
                     #[track(model.updates.changed(Updates::input_mode()))]
@@ -384,6 +383,7 @@ impl Component for Greeter {
         sender: ComponentSender<Self>,
         _root: &Self::Root,
     ) {
+        self.updates.reset();
         match msg {
             Self::CommandOutput::UpdateTime => self
                 .updates

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -140,9 +140,15 @@ impl Component for Greeter {
                 #[template_child]
                 background { set_filename: model.config.get_background().clone() },
                 #[template_child]
+                datetime_label {
+                    #[track(model.updates.changed(Updates::time()))]
+                    set_label: &model.updates.time
+                },
+
+                #[template_child]
                 message_label {
                     #[track(model.updates.changed(Updates::message()))]
-                    set_label: &model.updates.message
+                    set_label: &model.updates.message,
                 },
                 #[template_child]
                 session_label {
@@ -364,23 +370,20 @@ impl Component for Greeter {
     }
 
     /// Perform the requested changes when a background task sends a message.
-    fn update_cmd_with_view(
+    fn update_cmd(
         &mut self,
-        widgets: &mut Self::Widgets,
         msg: Self::CommandOutput,
         sender: ComponentSender<Self>,
         _root: &Self::Root,
     ) {
         match msg {
-            Self::CommandOutput::UpdateTime => widgets
-                .ui
-                .datetime_label
-                .set_label(&Local::now().format(DATETIME_FMT).to_string()),
+            Self::CommandOutput::UpdateTime => self
+                .updates
+                .set_time(Local::now().format(DATETIME_FMT).to_string()),
             Self::CommandOutput::ClearErr => self.updates.set_error(None), // TODO see if this works at all
             Self::CommandOutput::HandleGreetdResponse(response) => {
                 self.handle_greetd_response(&sender, response)
             }
         };
-        self.update_view(widgets, sender);
     }
 }

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -359,6 +359,8 @@ impl Component for Greeter {
     }
 
     fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
+        debug!("Got input message: {msg:?}");
+
         // Reset the tracker for update changes.
         self.updates.reset();
 
@@ -390,7 +392,13 @@ impl Component for Greeter {
         sender: ComponentSender<Self>,
         _root: &Self::Root,
     ) {
+        if !matches!(msg, Self::CommandOutput::UpdateTime) {
+            debug!("Got command message: {msg:?}");
+        }
+
+        // Reset the tracker for update changes.
         self.updates.reset();
+
         match msg {
             Self::CommandOutput::UpdateTime => self
                 .updates

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -298,11 +298,14 @@ impl Component for Greeter {
                     }
                 },
                 #[template_child]
+                error_info {
+                    #[track(model.updates.changed(Updates::error()))]
+                    set_revealed: model.updates.error.is_some(),
+                },
+                #[template_child]
                 error_label {
                     #[track(model.updates.changed(Updates::error()))]
                     set_label: model.updates.error.as_ref().unwrap_or(&"".to_string()),
-                    #[track(model.updates.changed(Updates::error()))]
-                    set_visible: model.updates.error.is_some(),
                 },
                 #[template_child]
                 reboot_button { connect_clicked => Self::Input::Reboot },
@@ -320,6 +323,10 @@ impl Component for Greeter {
     ) -> ComponentParts<Self> {
         let model = Self::new(&input.config_path);
         let widgets = view_output!();
+
+        // Make the info bar permanently visible, since it was made invisible during init. The
+        // actual visuals are controlled by `InfoBar::set_revealed`.
+        widgets.ui.error_info.set_visible(true);
 
         // cfg directives don't work inside Relm4 view! macro.
         #[cfg(feature = "gtk4_8")]

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -200,6 +200,7 @@ impl Component for Greeter {
                 input_label {
                     #[track(model.updates.changed(Updates::input_mode()))]
                     set_visible: model.updates.is_input(),
+                    #[track(model.updates.changed(Updates::input_prompt()))]
                     set_label: &model.updates.input_prompt,
                 },
                 #[template_child]

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -274,7 +274,6 @@ impl Component for Greeter {
                     connect_clicked[
                         sender,
                         secret_entry,
-                        visible_entry,
                         usernames_box,
                         username_entry,
                         sessions_box,

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -342,9 +342,7 @@ impl Component for Greeter {
         self.updates.reset();
 
         match msg {
-            Self::Input::Login { input, info } => {
-                self.login_click_handler(&sender, input, &info)
-            }
+            Self::Input::Login { input, info } => self.login_click_handler(&sender, input, &info),
             Self::Input::Cancel => self.cancel_click_handler(),
             Self::Input::UserChanged(info) => self.user_change_handler(&info),
             Self::Input::ToggleManualUser => self

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -5,6 +5,7 @@
 //! Message definitions for communication between the view and the model
 
 use derivative::Derivative;
+use greetd_ipc::Response;
 use relm4::gtk::{glib, prelude::*, ComboBoxText, Entry};
 
 #[derive(Debug)]
@@ -66,4 +67,6 @@ pub enum CommandMsg {
     UpdateTime,
     /// Clear the error message.
     ClearErr,
+    /// Handle a response received from greetd
+    HandleGreetdResponse(Response),
 }

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -44,7 +44,7 @@ pub enum InputMsg {
     /// Login request
     Login {
         #[derivative(Debug = "ignore")]
-        password: String,
+        input: String,
         info: UserSessInfo,
     },
     /// Cancel the login request

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -27,7 +27,7 @@ use super::messages::{CommandMsg, UserSessInfo};
 pub(super) const DEFAULT_MSG: &str = "Welcome back!";
 const ERROR_MSG_CLEAR_DELAY: u64 = 5;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 pub(super) enum InputMode {
     None,
     Secret,

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -54,6 +54,8 @@ pub(super) struct Updates {
     pub(super) input_mode: InputMode,
     /// ID of the active session
     pub(super) active_session_id: Option<String>,
+    /// Time that is displayed
+    pub(super) time: String,
 }
 
 impl Updates {
@@ -95,6 +97,7 @@ impl Greeter {
             input_prompt: String::new(),
             active_session_id: None,
             tracker: 0,
+            time: "".to_string(),
         };
         Self {
             greetd_client: Arc::new(Mutex::new(

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -249,7 +249,7 @@ impl Greeter {
                                     "Authentication message error from greetd: {auth_message}",
                                 ),
                             );
-                        },
+                        }
                     }
                 }
                 Response::Error { description, .. } => {
@@ -262,7 +262,10 @@ impl Greeter {
                     break;
                 }
             }
-            response = self.greetd_client.send_auth_response(None).unwrap_or_else(|err| panic!("Failed to respond to greetd: {err}"));
+            response = self
+                .greetd_client
+                .send_auth_response(None)
+                .unwrap_or_else(|err| panic!("Failed to respond to greetd: {err}"));
         }
     }
 
@@ -319,12 +322,7 @@ impl Greeter {
     }
 
     /// Send the entered input for logging in.
-    fn send_input(
-        &mut self,
-        sender: &ComponentSender<Self>,
-        input: String,
-        info: &UserSessInfo,
-    ) {
+    fn send_input(&mut self, sender: &ComponentSender<Self>, input: String, info: &UserSessInfo) {
         // TODO we should be able to remove this thanks to the new looping handler
         // Reset the password field, for convenience when the user has to re-enter a password.
         self.updates.set_input(String::new());

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -170,7 +170,7 @@ impl Greeter {
         // Before trying to create a session, check if the session command (if manually entered) is
         // valid.
         if self.updates.manual_sess_mode {
-            let info = self.sess_info.as_ref().unwrap();
+            let info = self.sess_info.as_ref().expect("No session info set yet");
             if shlex::split(info.sess_text.as_str()).is_none() {
                 // This must be an invalid command.
                 self.display_error(

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -223,14 +223,16 @@ impl Greeter {
                             // e.g.: a password
                             self.updates.set_input_mode(InputMode::Secret);
                             self.updates.set_input(String::new());
-                            self.updates.set_input_prompt(auth_message);
+                            self.updates
+                                .set_input_prompt(auth_message.trim_end().to_string());
                             break;
                         }
                         AuthMessageType::Visible => {
                             // Greetd has requested input that need not be hidden
                             self.updates.set_input_mode(InputMode::Visible);
                             self.updates.set_input(String::new());
-                            self.updates.set_input_prompt(auth_message);
+                            self.updates
+                                .set_input_prompt(auth_message.trim_end().to_string());
                             break;
                         }
                         AuthMessageType::Info => {

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -255,6 +255,8 @@ impl Greeter {
                     AuthMessageType::Error => {
                         // Greetd has sent an error message that should be displayed and logged
                         self.updates.set_input_mode(InputMode::None);
+                        // Reset outdated info message, if any
+                        self.updates.set_message(DEFAULT_MSG.to_string());
                         self.display_error(
                             sender,
                             &capitalize(&auth_message),

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -277,9 +277,8 @@ impl Greeter {
                 );
 
                 // In case this is an authentication error (e.g. wrong password), the session should be cancelled.
-                match error_type {
-                    ErrorType::Error => {}
-                    ErrorType::AuthError => self.cancel_click_handler(),
+                if let ErrorType::AuthError = error_type {
+                    self.cancel_click_handler()
                 }
                 return;
             }

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -232,6 +232,7 @@ impl Greeter {
                     AuthMessageType::Secret => {
                         // Greetd has requested input that should be hidden
                         // e.g.: a password
+                        info!("greetd asks for a secret auth input: {auth_message}");
                         self.updates.set_input_mode(InputMode::Secret);
                         self.updates.set_input(String::new());
                         self.updates
@@ -240,6 +241,7 @@ impl Greeter {
                     }
                     AuthMessageType::Visible => {
                         // Greetd has requested input that need not be hidden
+                        info!("greetd asks for a visible auth input: {auth_message}");
                         self.updates.set_input_mode(InputMode::Visible);
                         self.updates.set_input(String::new());
                         self.updates
@@ -249,6 +251,7 @@ impl Greeter {
                     AuthMessageType::Info => {
                         // Greetd has sent an info message that should be displayed
                         // e.g.: asking for a fingerprint
+                        info!("greetd sent an info: {auth_message}");
                         self.updates.set_input_mode(InputMode::None);
                         self.updates.set_message(auth_message);
                     }
@@ -286,6 +289,7 @@ impl Greeter {
 
         let client = Arc::clone(&self.greetd_client);
         sender.spawn_oneshot_command(move || {
+            debug!("Sending empty auth response to greetd");
             let response = client
                 .lock()
                 .unwrap()

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -450,8 +450,7 @@ impl Greeter {
                 self.updates.set_message("Logging in...".to_string());
             }
 
-            // The client should raise an `unimplemented!`, so ignore it.
-            Response::AuthMessage { .. } => (),
+            Response::AuthMessage { .. } => unimplemented!(),
 
             Response::Error { description, .. } => {
                 self.display_error(

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -149,7 +149,16 @@ impl WidgetTemplate for Ui {
                             add_css_class: "suggested-action",
                         },
                     },
-                }
+
+                    /// Warning/error messages
+                    attach[1, 4, 1, 1] = &gtk::Box {
+                        set_halign: gtk::Align::Center,
+
+                        // TODO add some styling (error symbol, different colour, ...)
+                        #[name = "error_label"]
+                        gtk::Label { },
+                    }
+                },
             },
 
             /// Clock widget

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -149,15 +149,6 @@ impl WidgetTemplate for Ui {
                             add_css_class: "suggested-action",
                         },
                     },
-
-                    /// Warning/error messages
-                    attach[1, 4, 1, 1] = &gtk::Box {
-                        set_halign: gtk::Align::Center,
-
-                        // TODO add some styling (error symbol, different colour, ...)
-                        #[name = "error_label"]
-                        gtk::Label { },
-                    }
                 },
             },
 
@@ -178,23 +169,52 @@ impl WidgetTemplate for Ui {
                 gtk::Label { set_width_request: 150 },
             },
 
-            /// Collection of buttons that close the greeter (eg. Reboot)
+            /// Collection of widgets appearing at the bottom
             add_overlay = &gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
                 set_halign: gtk::Align::Center,
                 set_valign: gtk::Align::End,
-                set_homogeneous: true,
                 set_margin_bottom: 15,
                 set_spacing: 15,
 
-                /// Button to reboot
-                #[name = "reboot_button"]
-                #[template]
-                EndButton { set_label: "Reboot" },
+                gtk::Frame {
+                    /// Notification bar for error messages
+                    #[name = "error_info"]
+                    gtk::InfoBar {
+                        // During init, the info bar closing animation is shown. To hide that, make
+                        // it invisible. Later, the code will permanently make it visible, so that
+                        // `InfoBar::set_revealed` will work properly with animations.
+                        set_visible: false,
+                        set_message_type: gtk::MessageType::Error,
 
-                /// Button to power-off
-                #[name = "poweroff_button"]
-                #[template]
-                EndButton { set_label: "Power Off" },
+                        /// The actual error message
+                        #[name = "error_label"]
+                        gtk::Label {
+                            set_halign: gtk::Align::Center,
+                            set_margin_top: 10,
+                            set_margin_bottom: 10,
+                            set_margin_start: 10,
+                            set_margin_end: 10,
+                        },
+                    }
+                },
+
+                /// Collection of buttons that close the greeter (eg. Reboot)
+                gtk::Box {
+                    set_halign: gtk::Align::Center,
+                    set_homogeneous: true,
+                    set_spacing: 15,
+
+                    /// Button to reboot
+                    #[name = "reboot_button"]
+                    #[template]
+                    EndButton { set_label: "Reboot" },
+
+                    /// Button to power-off
+                    #[name = "poweroff_button"]
+                    #[template]
+                    EndButton { set_label: "Power Off" },
+                },
             },
         }
     }

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -87,7 +87,7 @@ impl WidgetTemplate for Ui {
                     #[name = "usernames_box"]
                     attach[1, 1, 1, 1] = &gtk::ComboBoxText { set_hexpand: true },
 
-                    /// Widget where the user enters the password
+                    /// Widget where the user enters the username
                     #[name = "username_entry"]
                     attach[1, 1, 1, 1] = &gtk::Entry { set_hexpand: true },
 
@@ -95,21 +95,24 @@ impl WidgetTemplate for Ui {
                     #[name = "sessions_box"]
                     attach[1, 2, 1, 1] = &gtk::ComboBoxText,
 
-                    /// Widget where the user enters the password
+                    /// Widget where the user enters the session
                     #[name = "session_entry"]
                     attach[1, 2, 1, 1] = &gtk::Entry,
 
                     /// Label for the password widget
-                    #[name = "password_label"]
+                    #[name = "input_label"]
                     #[template]
                     attach[0, 2, 1, 1] = &EntryLabel {
-                        set_label: "Password:",
                         set_height_request: 45,
                     },
 
-                    /// Widget where the user enters the password
-                    #[name = "password_entry"]
+                    /// Widget where the user enters a secret
+                    #[name = "secret_entry"]
                     attach[1, 2, 1, 1] = &gtk::PasswordEntry { set_show_peek_icon: true },
+
+                    /// Widget where the user enters something visible
+                    #[name = "visible_entry"]
+                    attach[1, 2, 1, 1] = &gtk::Entry,
 
                     /// Button to toggle manual user entry
                     #[name = "user_toggle"]


### PR DESCRIPTION
The aim of this PR is to make ReGreet more suitable for the range of authentication procedures greetd supports. In its current state, ReGreet only really focuses on one style of authentication: username - password. However some setups do not match this, for example:

- fingerprint authentication (via fprint) works, but does not feel natural, as you are not logged in as soon as you've authenticated. Instead, you have to press login again. This current behaviour is mostly coincidental.
- If you use authentication that requires input but the input prompt doesn't contain the word "password" (possibly because you use a different language, a different type of secret input, or a visible input) you cannot use ReGreet because it doesn't show an input field
- Multi-step or fallback authentication is not supported, ReGreet will error or restart the session respectively.

To fix this and support all of greetd's authentication types, I have revised the way greetd responses are handled, taking inspiration from [agreety](https://github.com/kennylevinsen/greetd/blob/23fadf16d444164983784db5ce9d91d2c655fcd6/agreety/src/main.rs#L77). In case of an `info` or `error` authentication message, ReGreet now sends an empty authentication response immediately and waits for the next greetd response. Similarly, after an input such as a password is submitted, the exact same handling is performed, meaning that if greetd asks for more authentication, ReGreet can handle it now regardless of type.

This is the main change in this PR. A couple other changes have been made:
- ReGreet displays the authentication message from greetd as the input label now, instead of always "Password:". In the simple case of basic password authentication, the result is the same.
- `password_mode` has been replaced by `input_mode`, a three state enum specifying whether there is currently a secret input (equivalent to password_mode = true), a visible input (new feature) or no input (equivalent to password_mode = false).
- Most occurrences of "password" have been replaced by "input" or "secret", depending on whether the previous use was general or password-authentication specific. This is in line with greetd naming.

I've marked this PR as a draft because I still want to change the way responses are handled in a loop - currently this seems to block gtk/relm updates, meaning that info/error messages are not displayed. Maybe this can be circumvented by making use of `sender.oneshot_command(...)` or similar. I am practically completely unfamiliar with gtk and relm, so I'm open for suggestions.

Generally, I'll be happy to answer any questions you might have about the changes and discuss revisions.

