### PR TITLE
Start an X server for X11 sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "regreet"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "regreet"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Harish Rajagopal <harish.rajagopals@gmail.com>"]
 edition = "2021"
 rust-version = "1.70"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ GREETD\_CONFIG\_DIR | `/etc/greetd` | The configuration directory used by greetd
 CACHE\_DIR | `/var/cache/regreet` | The directory used to store cache
 LOG\_DIR | `/var/log/regreet` | The directory used to store logs
 SESSION\_DIRS | `/usr/share/xsessions:/usr/share/wayland-sessions` | A colon (:) separated list of directories where the greeter looks for session files
+X11\_CMD\_PREFIX | `startx /usr/bin/env` | The default command prefix for X11 sessions to launch the X server (see [this explanation on Reddit](https://web.archive.org/web/20240803120131/https://old.reddit.com/r/linux/comments/1c8zdcw/using_x11_window_managers_with_greetd_login/))
 REBOOT\_CMD | `reboot` | The default command used to reboot the system
 POWEROFF\_CMD | `poweroff` | The default command used to shut down the system
 LOGIN\_DEFS\_PATHS | `/etc/login.defs:/usr/etc/login.defs` | A colon (:) separated list of `login.defs` file paths. First found is loaded.
@@ -178,6 +179,7 @@ Currently, the following can be configured:
 * Font
 * Reboot command
 * Shut down command
+* X11 command prefix (see [this explanation on Reddit](https://web.archive.org/web/20240803120131/https://old.reddit.com/r/linux/comments/1c8zdcw/using_x11_window_managers_with_greetd_login/))
 
 ### Custom CSS
 ReGreet supports loading CSS files to act as a custom global stylesheet.

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -39,6 +39,9 @@ reboot = [ "systemctl", "reboot" ]
 # The command used to shut down the system
 poweroff = [ "systemctl", "poweroff" ]
 
+# The command prefix for X11 sessions to start the X server
+x11_prefix = [ "startx", "/usr/bin/env" ]
+
 [appearance]
 # The message that initially displays on startup
 greeting_msg = "Welcome back!"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::constants::{GREETING_MSG, POWEROFF_CMD, REBOOT_CMD};
+use crate::constants::{GREETING_MSG, POWEROFF_CMD, REBOOT_CMD, X11_CMD_PREFIX};
 use crate::tomlutils::load_toml;
 
 #[derive(Deserialize, Serialize)]
@@ -60,13 +60,15 @@ struct Background {
     fit: BgFit,
 }
 
-/// Struct for reboot/poweroff commands
+/// Struct for various system commands
 #[derive(Deserialize, Serialize)]
 pub struct SystemCommands {
     #[serde(default = "default_reboot_command")]
     pub reboot: Vec<String>,
     #[serde(default = "default_poweroff_command")]
     pub poweroff: Vec<String>,
+    #[serde(default = "default_x11_command_prefix")]
+    pub x11_prefix: Vec<String>,
 }
 
 impl Default for SystemCommands {
@@ -74,6 +76,7 @@ impl Default for SystemCommands {
         SystemCommands {
             reboot: default_reboot_command(),
             poweroff: default_poweroff_command(),
+            x11_prefix: default_x11_command_prefix(),
         }
     }
 }
@@ -84,6 +87,10 @@ fn default_reboot_command() -> Vec<String> {
 
 fn default_poweroff_command() -> Vec<String> {
     shlex::split(POWEROFF_CMD).expect("Unable to lex poweroff command")
+}
+
+fn default_x11_command_prefix() -> Vec<String> {
+    shlex::split(X11_CMD_PREFIX).expect("Unable to lex X11 command prefix")
 }
 
 fn default_greeting_msg() -> String {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -91,3 +91,6 @@ pub const SESSION_DIRS: &str = env_or!(
     "SESSION_DIRS",
     "/usr/share/xsessions:/usr/share/wayland-sessions"
 );
+
+/// Command prefix for X11 sessions to start the X server
+pub const X11_CMD_PREFIX: &str = env_or!("X11_CMD_PREFIX", "startx /usr/bin/env");

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -117,7 +117,7 @@ impl Greeter {
         ));
         Self {
             greetd_client,
-            sys_util: SysUtil::new().expect("Couldn't read available users and sessions"),
+            sys_util: SysUtil::new(&config).expect("Couldn't read available users and sessions"),
             cache: Cache::new(),
             sess_info: None,
             config,

--- a/src/sysutil.rs
+++ b/src/sysutil.rs
@@ -23,10 +23,23 @@ use crate::constants::{LOGIN_DEFS_PATHS, LOGIN_DEFS_UID_MAX, LOGIN_DEFS_UID_MIN,
 /// XDG data directory variable name (parent directory for X11/Wayland sessions)
 const XDG_DIR_ENV_VAR: &str = "XDG_DATA_DIRS";
 
+#[derive(Clone, Copy)]
+pub enum SessionType {
+    X11,
+    Wayland,
+    Unknown,
+}
+
+#[derive(Clone)]
+pub struct SessionInfo {
+    pub command: Vec<String>,
+    pub sess_type: SessionType,
+}
+
 // Convenient aliases for used maps
 type UserMap = HashMap<String, String>;
 type ShellMap = HashMap<String, Vec<String>>;
-type SessionMap = HashMap<String, Vec<String>>;
+type SessionMap = HashMap<String, SessionInfo>;
 
 /// Stores info of all regular users and sessions
 pub struct SysUtil {
@@ -290,7 +303,17 @@ impl SysUtil {
                     continue;
                 };
                 found_session_names.insert(fname_and_type);
-                sessions.insert(name.to_string(), cmd);
+                sessions.insert(
+                    name.to_string(),
+                    SessionInfo {
+                        command: cmd,
+                        sess_type: if is_x11 {
+                            SessionType::X11
+                        } else {
+                            SessionType::Wayland
+                        },
+                    },
+                );
             }
         }
 


### PR DESCRIPTION
This resolves #15 by prepending `startx /bin/env` to X11 session commands, to start an X server for an X11 session. Note that this assumes the existence of the `startx` and `/bin/env` commands.

Further, since this is only to be done for X11 sessions, this PR separates the `SESSION_DIRS` environment variable into `WAYLAND_SESSION_DIRS` and `XSESSION_DIRS`, since there's no way of knowing this from the session file itself.

@TLATER, since you seem to be a lot more familiar with this than me, can you test this and see if it works for your cases (and any other potential ones)?

EDIT: Also resolves #31.