### PR TITLE
Add config options for the reboot & shut down commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta
     - Icon theme
     - Cursor theme
     - Font
+* Allows changing reboot & poweroff commands for different init systems
 * Supports custom CSS files for further customizations
 
 ## Requirements
@@ -80,6 +81,8 @@ GREETD\_CONFIG\_DIR | `/etc/greetd` | The configuration directory used by greetd
 CACHE\_DIR | `/var/cache/regreet` | The directory used to store cache
 LOG\_DIR | `/var/log/regreet` | The directory used to store logs
 SESSION\_DIRS | `/usr/share/xsessions:/usr/share/wayland-sessions` | A colon (:) separated list of directories where the greeter looks for session files
+REBOOT\_CMD | `reboot` | The default command used to reboot the system
+POWEROFF\_CMD | `poweroff` | The default command used to shut down the system
 
 The greeter can be installed by copying the file `target/release/regreet` to `/usr/bin` (or similar directories like `/bin`).
 
@@ -154,6 +157,8 @@ Currently, the following can be configured:
 * Icon theme
 * Cursor theme
 * Font
+* Reboot command
+* Shut down command
 
 ### Custom CSS
 ReGreet supports loading CSS files to act as a custom global stylesheet.
@@ -167,6 +172,20 @@ regreet --style /path/to/custom.css
 
 Please refer to the GTK4 docs on [CSS in GTK](https://docs.gtk.org/gtk4/css-overview.html) and [GTK CSS Properties](https://docs.gtk.org/gtk4/css-properties.html) to learn how to style a GTK4 app using CSS.
 For a general reference on CSS, please refer to the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax).
+
+### Changing Reboot/Shut Down Commands
+The default reboot and shut down commands use the `reboot` and `poweroff` binaries, which are present on most Linux systems.
+However, since the recommended way of using ReGreet is to avoid running it as root, the `reboot`/`poweroff` commands might not work on systems where superuser access is needed to run these commands.
+In this case, if there is another command to reboot or shut down the system without superuser access, these commands can be set in the config file under the `[commands]` section.
+
+For example, to use `loginctl reboot` as the reboot command, use the following config:
+```toml
+[commands]
+reboot = [ "loginctl", "reboot" ]
+```
+Here, each command needs to be separated into a list containing the main command, followed by individual arguments.
+
+These commands can also be specified during compilation using the `REBOOT_CMD` and `POWEROFF_CMD` environment variables.
 
 ### Logging and Caching
 The cache is are stored in `/var/cache/regreet/cache.toml` (configurable during installation).

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -30,3 +30,10 @@ icon_theme_name = "Adwaita"
 
 # GTK theme name
 theme_name = "Adwaita"
+
+[commands]
+# The command used to reboot the system
+reboot = [ "systemctl", "reboot" ]
+
+# The command used to shut down the system
+poweroff = [ "systemctl", "poweroff" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,12 +38,21 @@ pub enum BgFit {
 }
 
 /// Struct for reboot/poweroff commands
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct SystemCommands {
     #[serde(default = "default_reboot_command")]
     pub reboot: Vec<String>,
     #[serde(default = "default_poweroff_command")]
     pub poweroff: Vec<String>,
+}
+
+impl Default for SystemCommands {
+    fn default() -> Self {
+        SystemCommands {
+            reboot: default_reboot_command(),
+            poweroff: default_poweroff_command(),
+        }
+    }
 }
 
 fn default_reboot_command() -> Vec<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::constants::{POWEROFF_CMD, REBOOT_CMD};
 use crate::tomlutils::load_toml;
 
 /// Struct holding all supported GTK settings
@@ -36,6 +37,23 @@ pub enum BgFit {
     ScaleDown,
 }
 
+/// Struct for reboot/poweroff commands
+#[derive(Default, Deserialize, Serialize)]
+pub struct SystemCommands {
+    #[serde(default = "default_reboot_command")]
+    pub reboot: Vec<String>,
+    #[serde(default = "default_poweroff_command")]
+    pub poweroff: Vec<String>,
+}
+
+fn default_reboot_command() -> Vec<String> {
+    shlex::split(REBOOT_CMD).expect("Unable to lex reboot command")
+}
+
+fn default_poweroff_command() -> Vec<String> {
+    shlex::split(POWEROFF_CMD).expect("Unable to lex poweroff command")
+}
+
 /// The configuration struct
 #[derive(Default, Deserialize, Serialize)]
 pub struct Config {
@@ -47,6 +65,8 @@ pub struct Config {
     pub background_fit: Option<BgFit>,
     #[serde(default, rename = "GTK")]
     gtk: Option<GtkSettings>,
+    #[serde(default)]
+    commands: SystemCommands,
 }
 
 impl Config {
@@ -69,5 +89,9 @@ impl Config {
 
     pub fn get_gtk_settings(&self) -> &Option<GtkSettings> {
         &self.gtk
+    }
+
+    pub fn get_sys_commands(&self) -> &SystemCommands {
+        &self.commands
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -41,6 +41,11 @@ const LOG_DIR: &str = env_or!("LOG_DIR", concatcp!("/var/log/", GREETER_NAME));
 /// Path to the cache file
 pub const LOG_PATH: &str = concatcp!(LOG_DIR, "/log");
 
+/// Default command for rebooting
+pub const REBOOT_CMD: &str = env_or!("REBOOT_CMD", "reboot");
+/// Default command for shutting down
+pub const POWEROFF_CMD: &str = env_or!("POWEROFF_CMD", "poweroff");
+
 /// Directories separated by `:`, containing desktop files for X11/Wayland sessions
 pub const SESSION_DIRS: &str = env_or!(
     "SESSION_DIRS",

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -380,8 +380,8 @@ impl Component for Greeter {
             Self::Input::ToggleManualSess => self
                 .updates
                 .set_manual_sess_mode(!self.updates.manual_sess_mode),
-            Self::Input::Reboot => Self::reboot_click_handler(&sender),
-            Self::Input::PowerOff => Self::poweroff_click_handler(&sender),
+            Self::Input::Reboot => self.reboot_click_handler(&sender),
+            Self::Input::PowerOff => self.poweroff_click_handler(&sender),
         }
     }
 


### PR DESCRIPTION
~This uses the crate [`system_shutdown`](https://crates.io/crates/system_shutdown) to perform a shutdown. This crate tries different DBus signals to shut down/reboot before falling back to the `shutdown`/`reboot` commands. Therefore, this change shouldn't (and on my laptop, doesn't) break for existing users.~

Now uses explicit commands set in the config file, that can also be specified during compilation.

Closes #14.