### PR TITLE
Fix slow session start

### DIFF
--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -451,8 +451,6 @@ impl Greeter {
             environment.push(format!("{}={}", k, v));
         }
 
-        self.updates.set_message("Logging in...".to_string());
-
         if let Some(username) = self.get_current_username() {
             self.cache.set_last_user(&username);
             if let Some(session) = session {


### PR DESCRIPTION
Fixes #18 

This PR changes the behaviour of ReGreet when the greeter is done and a session is supposed to be started. Before:

Ask greetd to start session
- on failure: display error but otherwise leave greeter in same state
- on success:
   1. Set user-session cache entry
   2. Save cache to disk
   3. Display "Logging In..." message
   4. Do nothing/wait for greetd to kill ReGreet process

Now:
1. Display "Logging in..." message
2. Set user-session cache entry
3. Save cache to disk
4. Ask greetd to start session
   - on success: exit process with code 0
   - on failure: invoke session cancel handler to reset ReGreet, display error

I think the fact that we save the cache even if the session start was not successful is no problem, given the lack of significance of this situation. But it is a thing that we could change according to [what I described](https://github.com/rharish101/ReGreet/issues/18#issuecomment-1484214083). Ideally the `LruCache` should implement `Clone` for this purpose. I don't think this is really necessary anymore.