### PR TITLE
Respect precedence of found desktop files and Hidden/NoDisplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta
     - Font
 * Allows changing reboot & poweroff commands for different init systems
 * Supports custom CSS files for further customizations
+* Respects `XDG_DATA_DIRS` environment variable
+* Respects fields `Hidden` and `NoDisplay` in session files
+* Picks up the first found session with the same name and in the same type (X11/Wayland). This allows for overriding system-provided session files.
 
 ## Requirements
 * Rust 1.64.0+ (for compilation only)

--- a/src/sysutil.rs
+++ b/src/sysutil.rs
@@ -201,7 +201,7 @@ impl SysUtil {
                 });
 
                 let fname_and_type = match path.strip_prefix(sess_parent_dir) {
-                    Ok(fname_and_type) => fname_and_type.as_os_str().to_os_string(),
+                    Ok(fname_and_type) => fname_and_type.to_owned(),
                     Err(err) => {
                         warn!("Error with file name: {err}");
                         continue;


### PR DESCRIPTION
Hi,

this PR implements precedence of desktop files (only first one with the same file name is used). It also respects Hidden/NoDisplay values of desktop entries.

The motivation for this is that I have my own modified versions of desktop files located in `/usr/local/share/wayland-session` which are using my own wrapper script, which are different than the ones which are installed by package manager.

It also respects `Hidden=true` and `NoDisplay=true`.

I've tested this in my system and it seems to work, however, this my first code in Rust, so it definitely might use some improvements.

Cheers