### PR TITLE
Make welcome message configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Currently, the following can be configured:
 * Background image
 * How the background image fits the screen (needs GTK 4.8+ support compiled)
 * Environment variables for created sessions
+* Greeting message
 * GTK theme
 * Dark mode
 * Icon theme

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -38,3 +38,7 @@ reboot = [ "systemctl", "reboot" ]
 
 # The command used to shut down the system
 poweroff = [ "systemctl", "poweroff" ]
+
+[appearance]
+# The message that initially displays on startup
+greeting_message = "Welcome back!"

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -41,4 +41,4 @@ poweroff = [ "systemctl", "poweroff" ]
 
 [appearance]
 # The message that initially displays on startup
-greeting_message = "Welcome back!"
+greeting_msg = "Welcome back!"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,19 @@ use serde::{Deserialize, Serialize};
 use crate::constants::{POWEROFF_CMD, REBOOT_CMD};
 use crate::tomlutils::load_toml;
 
+#[derive(Deserialize, Serialize)]
+pub struct AppearanceSettings {
+    pub greeting_msg: String,
+}
+
+impl std::default::Default for AppearanceSettings {
+    fn default() -> Self {
+        AppearanceSettings {
+            greeting_msg: String::from("Welcome back!"),
+        }
+    }
+}
+
 /// Struct holding all supported GTK settings
 #[derive(Default, Deserialize, Serialize)]
 pub struct GtkSettings {
@@ -76,6 +89,8 @@ fn default_poweroff_command() -> Vec<String> {
 #[derive(Default, Deserialize, Serialize)]
 pub struct Config {
     #[serde(default)]
+    appearance: AppearanceSettings,
+    #[serde(default)]
     env: HashMap<String, String>,
     #[serde(default)]
     background: Background,
@@ -109,5 +124,9 @@ impl Config {
 
     pub fn get_sys_commands(&self) -> &SystemCommands {
         &self.commands
+    }
+
+    pub fn get_default_message(&self) -> String {
+        self.appearance.greeting_msg.clone()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,18 +9,19 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::constants::{POWEROFF_CMD, REBOOT_CMD};
+use crate::constants::{GREETING_MSG, POWEROFF_CMD, REBOOT_CMD};
 use crate::tomlutils::load_toml;
 
 #[derive(Deserialize, Serialize)]
 pub struct AppearanceSettings {
+    #[serde(default = "default_greeting_msg")]
     pub greeting_msg: String,
 }
 
-impl std::default::Default for AppearanceSettings {
+impl Default for AppearanceSettings {
     fn default() -> Self {
         AppearanceSettings {
-            greeting_msg: String::from("Welcome back!"),
+            greeting_msg: default_greeting_msg(),
         }
     }
 }
@@ -83,6 +84,10 @@ fn default_reboot_command() -> Vec<String> {
 
 fn default_poweroff_command() -> Vec<String> {
     shlex::split(POWEROFF_CMD).expect("Unable to lex poweroff command")
+}
+
+fn default_greeting_msg() -> String {
+    GREETING_MSG.to_string()
 }
 
 /// The configuration struct

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -46,6 +46,9 @@ pub const REBOOT_CMD: &str = env_or!("REBOOT_CMD", "reboot");
 /// Default command for shutting down
 pub const POWEROFF_CMD: &str = env_or!("POWEROFF_CMD", "poweroff");
 
+/// Default greeting message
+pub const GREETING_MSG: &str = "Welcome back!";
+
 /// Directories separated by `:`, containing desktop files for X11/Wayland sessions
 pub const SESSION_DIRS: &str = env_or!(
     "SESSION_DIRS",

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -31,7 +31,6 @@ use crate::sysutil::SysUtil;
 
 use super::messages::{CommandMsg, UserSessInfo};
 
-pub(super) const DEFAULT_MSG: &str = "Welcome back!";
 const ERROR_MSG_CLEAR_DELAY: u64 = 5;
 
 #[derive(PartialEq)]
@@ -95,8 +94,10 @@ pub struct Greeter {
 
 impl Greeter {
     pub(super) async fn new(config_path: &Path) -> Self {
+        let config = Config::new(config_path);
+
         let updates = Updates {
-            message: DEFAULT_MSG.to_string(),
+            message: config.get_default_message(),
             error: None,
             input: String::new(),
             manual_user_mode: false,
@@ -117,8 +118,8 @@ impl Greeter {
             greetd_client,
             sys_util: SysUtil::new().expect("Couldn't read available users and sessions"),
             cache: Cache::new(),
-            config: Config::new(config_path),
             sess_info: None,
+            config,
             updates,
         }
     }
@@ -210,7 +211,7 @@ impl Greeter {
         };
         self.updates.set_input(String::new());
         self.updates.set_input_mode(InputMode::None);
-        self.updates.set_message(DEFAULT_MSG.to_string());
+        self.updates.set_message(self.config.get_default_message())
     }
 
     /// Create a greetd session, i.e. start a login attempt for the current user.
@@ -315,7 +316,7 @@ impl Greeter {
                         // Greetd has sent an error message that should be displayed and logged
                         self.updates.set_input_mode(InputMode::None);
                         // Reset outdated info message, if any
-                        self.updates.set_message(DEFAULT_MSG.to_string());
+                        self.updates.set_message(self.config.get_default_message());
                         self.display_error(
                             sender,
                             &capitalize(&auth_message),


### PR DESCRIPTION
Hi! Just a small change that closes #49. There are some things that could maybe go back and forth like the `.clone()` at `get_default_message` to reduce `.clone()` at callsites not matching the rest of the config because it returns an owned string but I think the rest should be good.

I was also thinking about a PR that chooses different background images based on aspect ratio/display name (I have a 3:2 laptop screen but plug in a 16:9 monitor that I'd like a different background on), but I know that `cage` can mirror across two screens and I wouldn't know if that would make the feature impossible. I'm not familiar with `relm4` and Wayland development in general so I'm a little fuzzy on what the behaviour would be in that case though I did spot `relm4::abstractions::drawing::DrawHandler::size` so that gives some hope for the possibility of dynamically detecting aspect ratio. 

From what I know to add background based on name would require speaking Wayland (`wl_output::name` unless relm4 or the gtk bindings abstract it) so that might be a dealbreaker since it'd add a lot of complexity. Let me know what you think about either of these ideas, I recognize it might be out of scope or just plain too much work to maintain.

- [x] Docs Updated
- [x] Pre-commit hooks passing