### PR TITLE
fix: Disambiguate `short='l'` in clap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,11 +42,11 @@ enum LogLevel {
 #[command(author, version, about)]
 struct Args {
     /// The path to the log file
-    #[arg(short, long, value_name = "PATH", default_value = LOG_PATH)]
+    #[arg(short = 'l', long, value_name = "PATH", default_value = LOG_PATH)]
     logs: PathBuf,
 
     /// The verbosity level of the logs
-    #[arg(short, long, value_name = "LEVEL", default_value = "info")]
+    #[arg(short = 'L', long, value_name = "LEVEL", default_value = "info")]
     log_level: LogLevel,
 
     /// Output all logs to stdout


### PR DESCRIPTION
Clap would panic at runtime because of a duplicate short=l option. I hope this gets merged quickly because pretty much all the testing that anyone would want to do would require them making this change before running regreet. And all the other branches can just be rebased onto this very small change probably with 0 conflict resoltion