### PR TITLE
ci: Add `cargo t` and cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,15 +20,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install GTK4
       run: sudo apt update && sudo apt install libgtk-4-dev build-essential
-    - name: Install Rust
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+    - run: rustup toolchain install stable --profile minimal
     - name: Restore build cache
       uses: Swatinem/rust-cache@v2
+
+    - run: cargo build --verbose
+    - run: cargo test --verbose
+
     - name: pre-commit
       uses: pre-commit/action@v3.0.0
     - uses: pre-commit-ci/lite-action@v1.0.0


### PR DESCRIPTION
actions-rs/toolchain is archived. Rust is currently installed on GitHub actions runners. So the action was replaced by using rustup to install a minimal profile.

And build and test staged were added.