### PR TITLE
rfct: power menu and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,19 +88,26 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
+name = "arc-swap"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "async-trait"
+version = "0.1.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -129,22 +136,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
+name = "basic-toml"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cairo-rs"
@@ -171,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -208,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -218,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -230,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -280,6 +311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,12 +344,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -346,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "field-offset"
@@ -371,6 +456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +472,50 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -495,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6efc7705f7863d37b12ad6974cbb310d35d054f5108cdc1e69037742f573c4c"
+checksum = "7563afd6ff0a221edfbb70a78add5075b8d9cb48e637a40a24c3ece3fea414d0"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -520,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0196720118f880f71fe7da971eff58cc43a89c9cf73f46076b7cb1e60889b15"
+checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -535,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b0e1340bd15e7a78810cf39fed9e5d85f0a8f80b1d999d384ca17dcc452b60"
+checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -548,6 +686,16 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -571,9 +719,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a517657589a174be9f60c667f1fec8b7ac82ed5db4ebf56cf073a3b5955d8e2e"
+checksum = "a4f00c70f8029d84ea7572dd0e1aaa79e5329667b4c17f329d79ffb1e6277487"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -588,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8446d9b475730ebef81802c1738d972db42fde1c5a36a627ebc4d665fc87db04"
+checksum = "160eb5250a26998c3e1b54e6a3d4ea15c6c7762a6062a19a7b63eff6e2b33f9e"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -601,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f969edf089188d821a30cde713b6f9eb08b20c63fc2e584aba2892a7984a8cc0"
+checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -635,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b360ff0f90d71de99095f79c526a5888c9c92fc9ee1b19da06c6f5e75f0c2a53"
+checksum = "a8928869a44cfdd1fccb17d6746e4ff82c8f82e41ce705aa026a52ca8dc3aefb"
 dependencies = [
  "libc",
  "system-deps",
@@ -651,9 +799,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gobject-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a56235e971a63bfd75abb13ef70064e1346388723422a68580d8a6fbac6423"
+checksum = "c773a3cb38a419ad9c26c81d177d96b4b08980e8bdbbf32dace883e96e96e7e3"
 dependencies = [
  "glib-sys",
  "libc",
@@ -662,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39d3bcd2e24fd9c2874a56f277b72c03e728de9bdc95a8d4ef4c962f10ced98"
+checksum = "3cbc5911bfb32d68dcfa92c9510c462696c2f715548fcd7f3f1be424c739de19"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -698,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b9188db0a6219e708b6b6e7225718e459def664023dbddb8395ca1486d8102"
+checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -713,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca10fc65d68528a548efa3d8747934adcbe7058b73695c9a7f43a25352fce14"
+checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -729,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697ff938136625f6acf75f01951220f47a45adcf0060ee55b4671cf734dac44"
+checksum = "af1c491051f030994fd0cde6f3c44f3f5640210308cff1298c7673c47408091d"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -762,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af4b680cee5d2f786a2f91f1c77e95ecf2254522f0ca4edf3a2dce6cb35cecf"
+checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -778,6 +926,12 @@ dependencies = [
  "pango-sys",
  "system-deps",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -813,6 +967,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "i18n-config"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0454970a5853f498e686cbd7bf9391aac2244928194780cb7a0af0f41937db6"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "locale_config",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7578cee2940492a648bd60fb49ca85ee8c821a63790e0ef5b604cfed353b2a"
+dependencies = [
+ "dashmap",
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,12 +1059,31 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
 ]
 
 [[package]]
@@ -859,35 +1100,38 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.16"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a46169c7a10358cdccfb179910e8a5a392fc291bdb409da9aeece5b19786d8"
+checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
 dependencies = [
  "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
  "serde",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
 dependencies = [
  "jiff-tzdb",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -915,10 +1159,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "libadwaita"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8611ee9fb85e7606c362b513afcaf5b59853f79e4d98caaaf581d99465014247"
+dependencies = [
+ "gdk4",
+ "gio",
+ "glib",
+ "gtk4",
+ "libadwaita-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "libadwaita-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b099a223560118d4d4fa04b6d23f3ea5b7171fe1d83dfb7e6b45b54cdfc83af9"
+dependencies = [
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"
@@ -932,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
@@ -942,7 +1230,16 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -962,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -1024,6 +1321,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "overload"
@@ -1046,9 +1372,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pango"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e89bd74250a03a05cec047b43465469102af803be2bf5e5a1088f8b8455e087"
+checksum = "6b1f5dc1b8cf9bc08bfc0843a04ee0fa2e78f1e1fa4b126844a383af4f25f0ec"
 dependencies = [
  "gio",
  "glib",
@@ -1058,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71787e0019b499a5eda889279e4adb455a4f3fdd6870cd5ab7f4a5aa25df6699"
+checksum = "0dbb9b751673bd8fe49eb78620547973a1e719ed431372122b20abd12445bab5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1069,10 +1395,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.15"
+name = "parking_lot"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1085,6 +1434,21 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1102,10 +1466,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1127,6 +1513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1170,22 +1565,26 @@ dependencies = [
  "greetd_ipc",
  "gtk4",
  "humantime-serde",
+ "i18n-embed",
+ "i18n-embed-fl",
  "jiff",
  "lazy_static",
  "lru",
  "pwd",
  "regex",
  "relm4",
+ "rust-embed",
  "serde",
  "shlex",
  "test-case",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
- "toml",
+ "toml 0.8.20",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "tracker",
+ "unic-langid",
 ]
 
 [[package]]
@@ -1198,6 +1597,7 @@ dependencies = [
  "fragile",
  "futures",
  "gtk4",
+ "libadwaita",
  "once_cell",
  "relm4-css",
  "relm4-macros",
@@ -1223,10 +1623,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1238,10 +1678,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1250,10 +1705,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.24"
+name = "self_cell"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.1.0",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -1277,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -1294,6 +1764,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1312,6 +1793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -1353,9 +1843,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1371,7 +1861,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.20",
  "version-compare",
 ]
 
@@ -1425,11 +1915,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1445,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1498,25 +1988,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.42.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
+name = "tokio"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1535,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -1637,10 +2146,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.14"
+name = "type-map"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-xid"
@@ -1656,15 +2199,31 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1674,20 +2233,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -1699,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1709,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1722,9 +2282,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -1741,6 +2304,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1841,9 +2413,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "regreet"
 version = "0.1.3"
 authors = ["Harish Rajagopal <harish.rajagopals@gmail.com>"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.80"
 description = "Clean and customizable greeter for greetd"
 repository = "https://github.com/rharish101/ReGreet/"
 license = "GPL-3.0-or-later"
@@ -22,21 +22,28 @@ glob = "0.3"
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = "0.9"
 humantime-serde = "1.1.1"
+i18n-embed = { version = "0.15.2", features = [
+    "desktop-requester",
+    "fluent-system",
+] }
+i18n-embed-fl = "0.9.2"
 jiff = "0.1.14"
 lazy_static = "1.5.0"
 lru = "0.12"
 pwd = "1.4.0"
 regex = "1.10"
-relm4 = "0.9"
+relm4 = { version = "0.9", features = ["adw", "libadwaita"] }
+rust-embed = "8.5.0"
 serde = { version = "1.0", features = ["derive"] }
 shlex = "1.3"
 thiserror = "2.0"
-tokio = { version = "1.39", features = ["net", "time"] }
+tokio = { version = "1.39", features = ["net", "process", "time"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["local-time"] }
 tracker = "0.2"
+unic-langid = "0.9.5"
 
 [features]
 gtk4_8 = ["gtk4/v4_8"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta
     - Icon theme
     - Cursor theme
     - Font
-* Allows changing reboot & poweroff commands for different init systems
+* Power menu: supports `systemd` out-of-the-box, and generic linux `shutdown` command. Support for other init systems is easy to add.
 * Supports custom CSS files for further customizations
 * Respects `XDG_DATA_DIRS` environment variable
 * Respects fields `Hidden` and `NoDisplay` in session files
@@ -50,7 +50,7 @@ These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta
 * Demo mode to run ReGreet without greetd for easier development.
 
 ## Requirements
-* Rust 1.75.0+ (for compilation only)
+* Rust 1.80.0+ (for compilation only)
 * greetd
 * GTK 4.0+
 * A Wayland compositor (such as [Cage](https://www.hjdskes.nl/projects/cage/) or [Sway](https://swaywm.org/) or [Hyprland](https://hyprland.org/))
@@ -94,8 +94,6 @@ CACHE\_DIR | `/var/cache/regreet` | The directory used to store cache
 LOG\_DIR | `/var/log/regreet` | The directory used to store logs
 SESSION\_DIRS | `/usr/share/xsessions:/usr/share/wayland-sessions` | A colon (:) separated list of directories where the greeter looks for session files
 X11\_CMD\_PREFIX | `startx /usr/bin/env` | The default command prefix for X11 sessions to launch the X server (see [this explanation on Reddit](https://web.archive.org/web/20240803120131/https://old.reddit.com/r/linux/comments/1c8zdcw/using_x11_window_managers_with_greetd_login/))
-REBOOT\_CMD | `reboot` | The default command used to reboot the system
-POWEROFF\_CMD | `poweroff` | The default command used to shut down the system
 LOGIN\_DEFS\_PATHS | `/etc/login.defs:/usr/etc/login.defs` | A colon (:) separated list of `login.defs` file paths. First found is loaded.
 LOGIN\_DEFS\_UID\_MIN | 1000 | Override the assumed default if `login.defs` doesnt specify `UID_MIN`.
 LOGIN\_DEFS\_UID\_MAX | 60000 | Override the assumed default if `login.defs` doesnt specify `UID_MAX`.
@@ -192,7 +190,7 @@ env = GTK_USE_PORTAL,0
 env = GDK_DEBUG,no-portals
 ```
 
-### Configuration
+## Configuration
 The configuration file must be in the [TOML](https://toml.io/) format.
 By default, it is named `regreet.toml`, and located in the greetd configuration directory specified during compilation (`/etc/greetd/` by default).
 You can use a config file in a different location with the `--config` argument as follows:
@@ -212,9 +210,17 @@ Currently, the following can be configured:
 * Icon theme
 * Cursor theme
 * Font
-* Reboot command
-* Shut down command
+* Power menu
 * X11 command prefix (see [this explanation on Reddit](https://web.archive.org/web/20240803120131/https://old.reddit.com/r/linux/comments/1c8zdcw/using_x11_window_managers_with_greetd_login/))
+
+### Widgets
+
+Widgets are additional UI elements that do not interact with `greetd`. Their configuration is under the `[widget]` key.
+See `regreet.sample.toml` for examples.
+
+- **Clock**: Located at the top of the screen and allows for `strftime`-like format speficiers.
+- **Power menu**: Supports `systemd` and a generic linux `shutdown` command. You can configure the order and presence of
+  power menu actions.
 
 **NOTE:** For configuring other essential features, such as the keyboard layout/mapping, the choice of monitor to use, etc., please check out the configuration options for the wayland compositor that you are using to run ReGreet.
 For example, if you use Cage, check out the [Cage wiki](https://github.com/cage-kiosk/cage/wiki/Configuration).
@@ -236,21 +242,7 @@ For a general reference on CSS, please refer to the [MDN web docs](https://devel
 
 **Tip:** You might want to use [demo mode](#demo-mode) to test out your CSS before making it permanent.
 
-### Changing Reboot/Shut Down Commands
-The default reboot and shut down commands use the `reboot` and `poweroff` binaries, which are present on most Linux systems.
-However, since the recommended way of using ReGreet is to avoid running it as root, the `reboot`/`poweroff` commands might not work on systems where superuser access is needed to run these commands.
-In this case, if there is another command to reboot or shut down the system without superuser access, these commands can be set in the config file under the `[commands]` section.
-
-For example, to use `loginctl reboot` as the reboot command, use the following config:
-```toml
-[commands]
-reboot = [ "loginctl", "reboot" ]
-```
-Here, each command needs to be separated into a list containing the main command, followed by individual arguments.
-
-These commands can also be specified during compilation using the `REBOOT_CMD` and `POWEROFF_CMD` environment variables.
-
-### Logging and Caching
+## Logging and Caching
 The cache is are stored in `/var/cache/regreet/cache.toml` (configurable during installation).
 It contains the last authenticated user and the last used session per user, which are automatically selected on next login.
 If the greeter is unable to write to this file, then it reverts to the default behaviour.

--- a/i18n.toml
+++ b/i18n.toml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Docs: https://crates.io/crates/cargo-i18n/
+
+fallback_language = "en"
+
+[fluent]
+assets_dir = "i18n"

--- a/i18n/en/regreet.ftl
+++ b/i18n/en/regreet.ftl
@@ -8,6 +8,7 @@ dialog-cancel = Cancel
 
 power-menu-tooltip = Power menu
 power-menu-poweroff = Poweroff
+power-menu-halt = Halt
 power-menu-reboot = Reboot
 power-menu-reboot-firmware = Reboot into firmware
 power-menu-suspend = Suspend

--- a/i18n/en/regreet.ftl
+++ b/i18n/en/regreet.ftl
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dialog-cancel = Cancel
+
+# Power menu
+
+power-menu-tooltip = Power menu
+power-menu-poweroff = Poweroff
+power-menu-reboot = Reboot
+power-menu-reboot-firmware = Reboot into firmware
+power-menu-suspend = Suspend
+power-menu-hibernate = Hibernate
+power-menu-hybrid-sleep = Hybrid sleep
+power-menu-confirm-dialog-heading = Really { $what }?

--- a/i18n/uk/regreet.ftl
+++ b/i18n/uk/regreet.ftl
@@ -8,6 +8,7 @@ dialog-cancel = Відмінити
 
 power-menu-tooltip = Керування живленням
 power-menu-poweroff = Вимкнути
+power-menu-halt = Зупинити
 power-menu-reboot = Перезапустити
 power-menu-reboot-firmware = Перезапустити до меню загрузки
 power-menu-suspend = Сон

--- a/i18n/uk/regreet.ftl
+++ b/i18n/uk/regreet.ftl
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dialog-cancel = Відмінити
+
+# Power menu
+
+power-menu-tooltip = Керування живленням
+power-menu-poweroff = Вимкнути
+power-menu-reboot = Перезапустити
+power-menu-reboot-firmware = Перезапустити до меню загрузки
+power-menu-suspend = Сон
+power-menu-hibernate = Гибернація
+power-menu-hybrid-sleep = Гібрідний сон
+power-menu-confirm-dialog-heading = Точно { $what }?

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -67,6 +67,8 @@ label_width = 150
 
 
 # The power menu widget
-[widget.power_menu.systemd]
-# Everything except `["hybernate", "hybrid-sleep"]`
-actions = ["poweroff", "reboot", "reboot-firmware", "suspend"]
+[widget.power_menu.systemd] # systemd-aware
+# [widget.power_menu.unix] # Uses the generic shutdown command
+
+# Selects what actions are displayed in the power menu
+actions = ["poweroff", "reboot"]

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -68,7 +68,10 @@ label_width = 150
 
 # The power menu widget
 [widget.power_menu.systemd] # systemd-aware
-# [widget.power_menu.unix] # Uses the generic shutdown command
 
 # Selects what actions are displayed in the power menu
 actions = ["poweroff", "reboot"]
+
+# You can also use this power menu type:
+#[widget.power_menu.unix]
+#actions = ["poweroff", "reboot", "halt"]

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -12,9 +12,11 @@ path = "/usr/share/backgrounds/greeter.jpg"
 # NOTE: This is ignored if ReGreet isn't compiled with GTK v4.8 support.
 fit = "Contain"
 
+
 # The entries defined in this section will be passed to the session as environment variables when it is started
 [env]
 ENV_VARIABLE = "value"
+
 
 [GTK]
 # Whether to use the dark theme
@@ -40,7 +42,7 @@ reboot = ["systemctl", "reboot"]
 poweroff = ["systemctl", "poweroff"]
 
 # The command prefix for X11 sessions to start the X server
-x11_prefix = [ "startx", "/usr/bin/env" ]
+x11_prefix = ["startx", "/usr/bin/env"]
 
 [appearance]
 # The message that initially displays on startup
@@ -62,3 +64,9 @@ timezone = "America/Chicago"
 # Ask GTK to make the label at least this wide. This helps keeps the parent element layout and width consistent.
 # Experiment with different widths, the interpretation of this value is entirely up to GTK.
 label_width = 150
+
+
+# The power menu widget
+[widget.power_menu.systemd]
+# Everything except `["hybernate", "hybrid-sleep"]`
+actions = ["poweroff", "reboot", "reboot-firmware", "suspend"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::constants::{GREETING_MSG, POWEROFF_CMD, REBOOT_CMD, X11_CMD_PREFIX};
 use crate::gui::widget::clock::ClockConfig;
+use crate::gui::widget::power_menu::PowerMenuConfig;
 use crate::tomlutils::load_toml;
 
 #[derive(Deserialize, Serialize)]
@@ -124,6 +125,9 @@ pub struct Config {
 pub struct WidgetConfig {
     #[serde(default)]
     pub(crate) clock: ClockConfig,
+
+    #[serde(default)]
+    pub(crate) power_menu: PowerMenuConfig,
 }
 
 impl Config {
@@ -154,5 +158,19 @@ impl Config {
 
     pub fn get_default_message(&self) -> String {
         self.appearance.greeting_msg.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tomlutils::{load_raw_toml, TomlFileResult};
+
+    use super::*;
+
+    #[test]
+    fn sample_config_works() -> TomlFileResult<()> {
+        let _: Config = load_raw_toml("regreet.sample.toml")?;
+
+        Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::constants::{GREETING_MSG, POWEROFF_CMD, REBOOT_CMD, X11_CMD_PREFIX};
+use crate::constants::{GREETING_MSG, X11_CMD_PREFIX};
 use crate::gui::widget::clock::ClockConfig;
 use crate::gui::widget::power_menu::PowerMenuConfig;
 use crate::tomlutils::load_toml;
@@ -65,10 +65,6 @@ struct Background {
 /// Struct for various system commands
 #[derive(Deserialize, Serialize)]
 pub struct SystemCommands {
-    #[serde(default = "default_reboot_command")]
-    pub reboot: Vec<String>,
-    #[serde(default = "default_poweroff_command")]
-    pub poweroff: Vec<String>,
     #[serde(default = "default_x11_command_prefix")]
     pub x11_prefix: Vec<String>,
 }
@@ -76,19 +72,9 @@ pub struct SystemCommands {
 impl Default for SystemCommands {
     fn default() -> Self {
         SystemCommands {
-            reboot: default_reboot_command(),
-            poweroff: default_poweroff_command(),
             x11_prefix: default_x11_command_prefix(),
         }
     }
-}
-
-fn default_reboot_command() -> Vec<String> {
-    shlex::split(REBOOT_CMD).expect("Unable to lex reboot command")
-}
-
-fn default_poweroff_command() -> Vec<String> {
-    shlex::split(POWEROFF_CMD).expect("Unable to lex poweroff command")
 }
 
 fn default_x11_command_prefix() -> Vec<String> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,11 +39,6 @@ const LOG_DIR: &str = env_or!("LOG_DIR", concatcp!("/var/log/", GREETER_NAME));
 /// Path to the cache file
 pub const LOG_PATH: &str = concatcp!(LOG_DIR, "/log");
 
-/// Default command for rebooting
-pub const REBOOT_CMD: &str = env_or!("REBOOT_CMD", "reboot");
-/// Default command for shutting down
-pub const POWEROFF_CMD: &str = env_or!("POWEROFF_CMD", "poweroff");
-
 /// Default greeting message
 pub const GREETING_MSG: &str = "Welcome back!";
 

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -22,7 +22,7 @@ use super::model::{Greeter, InputMode, Updates};
 use super::templates::Ui;
 
 /// Load GTK settings from the greeter config.
-fn setup_settings(model: &Greeter, root: &gtk::ApplicationWindow) {
+fn setup_settings(model: &Greeter, root: &adw::ApplicationWindow) {
     let settings = root.settings();
     let config = if let Some(config) = model.config.get_gtk_settings() {
         config
@@ -113,7 +113,7 @@ impl AsyncComponent for Greeter {
     view! {
         // The `view!` macro needs a proper widget, not a template, as the root.
         #[name = "window"]
-        gtk::ApplicationWindow {
+        adw::ApplicationWindow {
             set_visible: true,
 
             // Name the UI widget, otherwise the inner children cannot be accessed by name.
@@ -126,6 +126,14 @@ impl AsyncComponent for Greeter {
                 #[template_child]
                 clock_frame {
                     model.clock.widget(),
+                },
+
+                #[template_child]
+                panel_end {
+                    append = model.power_menu.widget() {
+                        set_halign: gtk::Align::End,
+                        set_hexpand: false,
+                    },
                 },
 
                 #[template_child]
@@ -306,10 +314,6 @@ impl AsyncComponent for Greeter {
                     #[track(model.updates.changed(Updates::error()))]
                     set_label: model.updates.error.as_ref().unwrap_or(&"".to_string()),
                 },
-                #[template_child]
-                reboot_button { connect_clicked => Self::Input::Reboot },
-                #[template_child]
-                poweroff_button { connect_clicked => Self::Input::PowerOff },
             }
         }
     }
@@ -413,8 +417,6 @@ impl AsyncComponent for Greeter {
             Self::Input::ToggleManualSess => self
                 .updates
                 .set_manual_sess_mode(!self.updates.manual_sess_mode),
-            Self::Input::Reboot => self.reboot_click_handler(&sender),
-            Self::Input::PowerOff => self.poweroff_click_handler(&sender),
         }
     }
 

--- a/src/gui/icons.rs
+++ b/src/gui/icons.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+macro_rules! icons {
+    ($($name:ident = $value:expr),+$(,)?) => {
+        $(pub const $name: &str = $value;)+
+    };
+}
+
+icons![
+    POWER_MENU = self::POWEROFF,
+    POWEROFF = "system-shutdown-symbolic",
+    REBOOT = "system-reboot-symbolic",
+    REBOOT_FIRMWARE = "application-x-firmware-symbolic",
+    SUSPEND = "system-suspend-symbolic",
+    HIBERNATE = "system-hibernate-symbolic",
+];

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -56,8 +56,6 @@ pub enum InputMsg {
     ToggleManualUser,
     /// Toggle manual entry of session.
     ToggleManualSess,
-    Reboot,
-    PowerOff,
 }
 
 #[derive(Debug)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -16,3 +16,5 @@ pub mod icons;
 
 pub use component::GreeterInit;
 pub use model::Greeter;
+
+const GAP: i32 = 15;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -10,7 +10,9 @@ mod model;
 mod templates;
 pub(crate) mod widget {
     pub mod clock;
+    pub mod power_menu;
 }
+pub mod icons;
 
 pub use component::GreeterInit;
 pub use model::Greeter;

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -8,6 +8,8 @@
 use gtk::prelude::*;
 use relm4::{gtk, RelmWidgetExt, WidgetTemplate};
 
+use crate::gui::GAP;
+
 /// Label for an entry/combo box
 #[relm4::widget_template(pub)]
 impl WidgetTemplate for EntryLabel {
@@ -35,18 +37,18 @@ impl WidgetTemplate for Ui {
                 add_css_class: "background",
 
                 gtk::Grid {
-                    set_column_spacing: 15,
-                    set_margin_bottom: 15,
-                    set_margin_end: 15,
-                    set_margin_start: 15,
-                    set_margin_top: 15,
-                    set_row_spacing: 15,
+                    set_column_spacing: GAP as u32,
+                    set_margin_bottom: GAP,
+                    set_margin_end: GAP,
+                    set_margin_start: GAP,
+                    set_margin_top: GAP,
+                    set_row_spacing: GAP as u32,
                     set_width_request: 500,
 
                     /// Widget to display messages to the user
                     #[name = "message_label"]
                     attach[0, 0, 3, 1] = &gtk::Label {
-                        set_margin_bottom: 15,
+                        set_margin_bottom: GAP,
 
                         // Format all messages in boldface.
                         #[wrap(Some)]
@@ -121,7 +123,7 @@ impl WidgetTemplate for Ui {
                     /// Collection of action buttons (eg. Login)
                     attach[1, 3, 2, 1] = &gtk::Box {
                         set_halign: gtk::Align::End,
-                        set_spacing: 15,
+                        set_spacing: GAP,
 
                         /// Button to cancel password entry
                         #[name = "cancel_button"]
@@ -171,12 +173,10 @@ impl WidgetTemplate for Ui {
 
 
             /// Collection of widgets appearing at the bottom
-            add_overlay = &gtk::Box {
-                set_orientation: gtk::Orientation::Vertical,
+            add_overlay = &gtk::Box::new(gtk::Orientation::Vertical, GAP) {
                 set_halign: gtk::Align::Center,
                 set_valign: gtk::Align::End,
-                set_margin_bottom: 15,
-                set_spacing: 15,
+                set_margin_bottom: GAP,
 
                 gtk::Frame {
                     /// Notification bar for error messages

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -8,17 +8,6 @@
 use gtk::prelude::*;
 use relm4::{gtk, RelmWidgetExt, WidgetTemplate};
 
-/// Button that ends the greeter (eg. Reboot)
-#[relm4::widget_template(pub)]
-impl WidgetTemplate for EndButton {
-    view! {
-        gtk::Button {
-            set_focusable: true,
-            add_css_class: "destructive-action",
-        }
-    }
-}
-
 /// Label for an entry/combo box
 #[relm4::widget_template(pub)]
 impl WidgetTemplate for EntryLabel {
@@ -153,21 +142,33 @@ impl WidgetTemplate for Ui {
                 },
             },
 
-            /// Clock widget
-            #[name = "clock_frame"]
-            add_overlay = &gtk::Frame {
-                set_halign: gtk::Align::Center,
+            add_overlay = &gtk::CenterBox {
+                set_halign: gtk::Align::Fill,
                 set_valign: gtk::Align::Start,
+                set_hexpand:true,
 
-                add_css_class: "background",
+                /// Clock widget
+                #[name = "clock_frame"]
+                #[wrap(Some)]
+                set_center_widget = &gtk::Frame {
+                    add_css_class: "background",
 
-                // Make it fit cleanly onto the top edge of the screen.
-                inline_css: "
-                    border-top-right-radius: 0px;
-                    border-top-left-radius: 0px;
-                    border-top-width: 0px;
-                ",
+                    // Make it fit cleanly onto the top edge of the screen.
+                    inline_css: "
+                        border-top-right-radius: 0px;
+                        border-top-left-radius: 0px;
+                        border-top-width: 0px;
+                    ",
+                },
+
+                #[name = "panel_end"]
+                #[wrap(Some)]
+                set_end_widget = &gtk::Box {
+                    set_hexpand: true,
+                    set_halign: gtk::Align::End,
+                },
             },
+
 
             /// Collection of widgets appearing at the bottom
             add_overlay = &gtk::Box {
@@ -197,23 +198,6 @@ impl WidgetTemplate for Ui {
                             set_margin_end: 10,
                         },
                     }
-                },
-
-                /// Collection of buttons that close the greeter (eg. Reboot)
-                gtk::Box {
-                    set_halign: gtk::Align::Center,
-                    set_homogeneous: true,
-                    set_spacing: 15,
-
-                    /// Button to reboot
-                    #[name = "reboot_button"]
-                    #[template]
-                    EndButton { set_label: "Reboot" },
-
-                    /// Button to power-off
-                    #[name = "poweroff_button"]
-                    #[template]
-                    EndButton { set_label: "Power Off" },
                 },
             },
         }

--- a/src/gui/widget/power_menu/mod.rs
+++ b/src/gui/widget/power_menu/mod.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A [serde-configurable][`PowerMenuConfig`] power menu.
+
+use relm4::prelude::*;
+use serde::Deserialize;
+use systemd::{SystemdPowerMenu, SystemdPowerMenuConfig};
+
+use crate::{fl, gui::icons};
+
+mod systemd;
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum PowerMenuConfig {
+    /// Systemd-aware widget
+    Systemd(SystemdPowerMenuConfig),
+}
+
+impl Default for PowerMenuConfig {
+    fn default() -> Self {
+        Self::Systemd(Default::default())
+    }
+}
+
+pub struct PowerMenu {
+    menu: AsyncController<SystemdPowerMenu>,
+}
+
+#[relm4::component(pub)]
+impl Component for PowerMenu {
+    type Init = PowerMenuConfig;
+    type Input = ();
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        gtk::MenuButton {
+            set_icon_name: icons::POWER_MENU,
+            set_tooltip: &fl!("power-menu-tooltip"),
+
+            #[wrap(Some)]
+            set_popover = &gtk::Popover {
+                model.menu.widget() { },
+            },
+        }
+    }
+
+    fn init(
+        PowerMenuConfig::Systemd(systemd_config): Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self {
+            menu: SystemdPowerMenu::builder().launch(systemd_config).detach(),
+        };
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+}

--- a/src/gui/widget/power_menu/systemd.rs
+++ b/src/gui/widget/power_menu/systemd.rs
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A systemd-aware power menu widget.
+
+use std::collections::HashSet;
+
+use relm4::{
+    gtk::{glib::markup_escape_text, prelude::*},
+    prelude::{AsyncComponentParts, *},
+    AsyncComponentSender,
+};
+use tokio::process::Command;
+
+use crate::{demo, fl, i18n::lowercase_first_char};
+
+macro_rules! actions {
+    ($($variant:ident = $systemctl_args:expr; $icon:ident),+ $(,)?) => {
+        #[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[serde(rename_all = "snake_case")]
+        pub enum Action {
+            $($variant),+
+        }
+
+        impl Action {
+            /// Every variant as a [`Vec`].
+            pub fn all() -> Vec<Action> {
+                // It is easier to use a macro than adding a complex dependency.
+               [$(Action::$variant),+].into()
+            }
+
+            pub fn systemctl_args(&self) -> &'static[&'static str] {
+                match self {
+                    $(Self::$variant => &$systemctl_args[..]),+
+                }
+            }
+
+            pub fn icon(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => crate::gui::icons::$icon),+
+                }
+            }
+        }
+
+    };
+}
+
+actions! {
+    Poweroff = ["poweroff"]; POWEROFF,
+    Reboot = ["reboot"]; REBOOT,
+    RebootFirmware = ["reboot", "--firmware-setup"]; REBOOT_FIRMWARE,
+    Suspend = ["suspend"]; SUSPEND,
+    Hibernate = ["hibernate"]; HIBERNATE,
+    HybridSleep = ["hybrid-sleep"]; HIBERNATE, // TODO: Is there an icon for it?
+}
+
+impl Action {
+    /// Returns the [`crate::fl!`] for the variant using this format: `fl!("power-menu-{snake-case}")`
+    fn fl(&self) -> String {
+        use Action as A;
+        match self {
+            A::Poweroff => fl!("power-menu-poweroff"),
+            A::Reboot => fl!("power-menu-reboot"),
+            A::RebootFirmware => fl!("power-menu-reboot-firmware"),
+            A::Suspend => fl!("power-menu-suspend"),
+            A::Hibernate => fl!("power-menu-hibernate"),
+            A::HybridSleep => fl!("power-menu-hybrid-sleep"),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct SystemdPowerMenuConfig {
+    /// The list of actions to show. Order is preserved. The first unique occurance is used, with duplicates discarded.
+    /// E.g. `["poweroff", "reboot", "poweroff"]` Results in this order of widgets: Poweroff, Reboot.
+    ///
+    /// See [`Action`] for all available actions and what they do.
+    #[serde(default = "Action::all")]
+    pub actions: Vec<Action>,
+}
+
+impl Default for SystemdPowerMenuConfig {
+    fn default() -> Self {
+        Self {
+            actions: Action::all(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum SystemdPowerMenu {
+    /// The default state with all buttons shown.
+    Menu,
+
+    /// The confimation widget for a specific action.
+    Confirm(Action),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemdPowerMenuMsg {
+    /// Sent when the user selected a power menu button. If the action requires confirmation (involves a poweroff of the
+    /// system) a confirmation screen is shown ([`SystemdPowerMenu::Confirm`] state).
+    Request(Action),
+
+    /// A confirmation of a [`Self::Request`] was cancelled. Has no effect if no confirmation is requested.
+    Cancel,
+
+    /// Confirms an action that was requested in [`Self::Request`]. Has no effect if no confirmation is requested.
+    Confirm,
+}
+
+#[relm4::component(pub, async)]
+impl AsyncComponent for SystemdPowerMenu {
+    type Init = SystemdPowerMenuConfig;
+    type Input = SystemdPowerMenuMsg;
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        gtk::Box {
+            #[name = "menu"]
+            #[transition(Crossfade)]
+            match model {
+                Self::Menu => &gtk::Box::new(gtk::Orientation::Vertical, 15) {
+                    gtk::Label {
+                        set_markup: &format!("<big><b>{}</b> (Systemd)</big>", fl!("power-menu-tooltip")),
+                    },
+
+                    #[iterate]
+                    append: &action_buttons(actions, sender.clone()),
+                },
+
+                Self::Confirm(action) => &gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_spacing: 15,
+
+                    gtk::Label {
+                        #[watch]
+                        set_markup: &format!("<big><b>{}</b></big>",
+                            markup_escape_text(&fl!("power-menu-confirm-dialog-heading",
+                                what = lowercase_first_char(&action.fl()))
+                            )
+                        ),
+                    },
+
+                    gtk::Box {
+                        set_spacing: 15,
+
+                        gtk::Button {
+                            set_label: &fl!("dialog-cancel"),
+
+                            connect_clicked => SystemdPowerMenuMsg::Cancel,
+                        },
+
+                        gtk::Button {
+                            add_css_class: "destructive-action",
+
+                            #[watch]
+                            set_label: &action.fl(),
+
+                            connect_clicked => SystemdPowerMenuMsg::Confirm,
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    async fn init(
+        SystemdPowerMenuConfig { actions }: Self::Init,
+        root: Self::Root,
+        sender: AsyncComponentSender<Self>,
+    ) -> AsyncComponentParts<Self> {
+        let model = Self::Menu;
+        let widgets = view_output!();
+
+        widgets.menu.set_vhomogeneous(false);
+        widgets.menu.set_hhomogeneous(false);
+
+        AsyncComponentParts { model, widgets }
+    }
+
+    async fn update(
+        &mut self,
+        message: Self::Input,
+        sender: AsyncComponentSender<Self>,
+        _: &Self::Root,
+    ) {
+        use SystemdPowerMenuMsg as M;
+        let action = match &message {
+            M::Request(action) => *action,
+
+            M::Confirm => {
+                let Self::Confirm(what) = self else { return };
+                *what
+            }
+
+            M::Cancel => {
+                *self = Self::Menu;
+                return;
+            }
+        };
+
+        use Action as A;
+        let require_confirm = *self == Self::Menu
+            && matches!(
+                &message,
+                M::Request(A::Poweroff | A::Reboot | A::RebootFirmware)
+            );
+
+        if require_confirm {
+            *self = Self::Confirm(action);
+            return;
+        }
+
+        if demo() {
+            info!("Demo mode: not doing {action:?}");
+            *self = Self::Menu;
+
+            return;
+        }
+
+        let systemctl = Command::new("systemctl")
+            .args(action.systemctl_args())
+            .status();
+
+        sender.oneshot_command(async move {
+            let Err(why) = systemctl.await else { return };
+            debug!("Failed to {action:?}: {why}");
+        });
+    }
+}
+
+fn action_buttons(
+    activated: Vec<Action>,
+    sender: AsyncComponentSender<SystemdPowerMenu>,
+) -> Vec<gtk::Button> {
+    let len = activated.len();
+    let mut mentioned = HashSet::new();
+
+    activated
+        .into_iter()
+        .fold(Vec::with_capacity(len), |mut acc, action| {
+            if !mentioned.insert(action) {
+                return acc;
+            }
+
+            let label = gtk::Label::new(Some(&action.fl()));
+            let icon = gtk::Image::new();
+            icon.set_icon_name(Some(action.icon()));
+
+            let container = gtk::Box::new(gtk::Orientation::Horizontal, 15);
+            container.append(&icon);
+            container.append(&label);
+
+            let button = gtk::Button::new();
+            button.set_child(Some(&container));
+
+            let sender = sender.clone();
+            button.connect_clicked(move |_| sender.input(SystemdPowerMenuMsg::Request(action)));
+
+            acc.push(button);
+            acc
+        })
+}

--- a/src/gui/widget/power_menu/unix.rs
+++ b/src/gui/widget/power_menu/unix.rs
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A power menu widget that uses the generic `man 8 shutdown` linux command.
+//!
+//! See supported actions as variants of [`Action`].
+
+use std::collections::HashSet;
+
+use relm4::{adw::glib::markup_escape_text, adw::prelude::*, prelude::*};
+use tokio::process::Command;
+
+use crate::{
+    demo, fl,
+    gui::{icons, GAP},
+    i18n::lowercase_first_char,
+};
+
+#[derive(Deserialize, Clone)]
+pub struct UnixPowerMenuConfig {
+    #[serde(default = "Action::default_set")]
+    actions: Vec<Action>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Action {
+    Poweroff,
+    Reboot,
+    Halt,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum UnixPowerMenu {
+    Menu,
+    Confirm(Action),
+}
+
+#[derive(Debug)]
+pub enum UnixPowerMenuMsg {
+    Request(Action),
+    Confirm,
+    Cancel,
+}
+
+#[relm4::component(pub, async)]
+impl AsyncComponent for UnixPowerMenu {
+    type Init = UnixPowerMenuConfig;
+    type Input = UnixPowerMenuMsg;
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        gtk::Box {
+            #[name = "menu"]
+            #[transition(Crossfade)]
+            match model {
+                Self::Menu => &gtk::Box::new(gtk::Orientation::Vertical, GAP) {
+                    gtk::Label {
+                        set_markup: &format!("<big><b>{}</b> (Unix)</big>", fl!("power-menu-tooltip"))
+                    },
+
+                    #[iterate]
+                    append: &action_buttons(actions, sender.clone()),
+                },
+
+                Self::Confirm(action) => &gtk::Box::new(gtk::Orientation::Vertical, GAP) {
+                    gtk::Label {
+                        #[watch]
+                        set_markup: &format!("<big><b>{}</b></big>",
+                            markup_escape_text(&fl!("power-menu-confirm-dialog-heading",
+                                what = lowercase_first_char(&action.fl()))
+                            )
+                        ),
+                    },
+
+                    gtk::Box {
+                        set_spacing: GAP,
+
+                        gtk::Button::with_label(&fl!("dialog-cancel")) {
+                            connect_clicked => UnixPowerMenuMsg::Cancel,
+                        },
+
+                        gtk::Button {
+                            add_css_class: "destructive-action",
+
+                            #[watch]
+                            set_label: &action.fl(),
+
+                            connect_clicked => UnixPowerMenuMsg::Confirm,
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    async fn init(
+        UnixPowerMenuConfig { actions }: Self::Init,
+        root: Self::Root,
+        sender: relm4::AsyncComponentSender<Self>,
+    ) -> AsyncComponentParts<Self> {
+        let model = Self::Menu;
+        let widgets = view_output!();
+
+        widgets.menu.set_vhomogeneous(false);
+        widgets.menu.set_hhomogeneous(false);
+
+        AsyncComponentParts { model, widgets }
+    }
+
+    async fn update(
+        &mut self,
+        message: Self::Input,
+        sender: AsyncComponentSender<Self>,
+        _: &Self::Root,
+    ) {
+        use UnixPowerMenuMsg as M;
+        let action = match &message {
+            M::Request(action) => *action,
+
+            M::Confirm => {
+                let Self::Confirm(what) = self else { return };
+                *what
+            }
+
+            M::Cancel => {
+                *self = Self::Menu;
+                return;
+            }
+        };
+
+        if *self == Self::Menu {
+            *self = Self::Confirm(action);
+            return;
+        }
+
+        if demo() {
+            info!("Demo mode: not doing {action:?}");
+            *self = Self::Menu;
+
+            return;
+        }
+
+        let shutdown = Command::new("shutdown")
+            .args(action.shutdown_args())
+            .status();
+
+        sender.oneshot_command(async move {
+            let Err(why) = shutdown.await else { return };
+            debug!("Failed to {action:?}: {why}");
+        });
+    }
+}
+
+fn action_buttons(
+    activated: Vec<Action>,
+    sender: AsyncComponentSender<UnixPowerMenu>,
+) -> Vec<gtk::Button> {
+    let len = activated.len();
+    let mut mentioned = HashSet::new();
+
+    activated
+        .into_iter()
+        .fold(Vec::with_capacity(len), |mut acc, action| {
+            if !mentioned.insert(action) {
+                return acc;
+            }
+
+            let label = gtk::Label::new(Some(&action.fl()));
+            let icon = gtk::Image::new();
+            icon.set_icon_name(Some(action.icon()));
+
+            let container = gtk::Box::new(gtk::Orientation::Horizontal, GAP);
+            container.append(&icon);
+            container.append(&label);
+
+            let button = gtk::Button::new();
+            button.set_child(Some(&container));
+
+            let sender = sender.clone();
+            button.connect_clicked(move |_| sender.input(UnixPowerMenuMsg::Request(action)));
+
+            acc.push(button);
+            acc
+        })
+}
+
+impl Action {
+    /// Sensible default set of actions that most users would find sufficient.
+    pub fn default_set() -> Vec<Self> {
+        [Self::Poweroff, Self::Reboot].into()
+    }
+
+    pub const fn shutdown_args(&self) -> &'static [&'static str] {
+        match self {
+            Self::Poweroff => &["--poweroff", "now"],
+            Self::Reboot => &["--reboot", "now"],
+            Self::Halt => &["--halt", "now"],
+        }
+    }
+
+    /// Returns the icon name for this action
+    pub const fn icon(&self) -> &'static str {
+        match self {
+            Self::Poweroff => icons::POWEROFF,
+            Self::Reboot => icons::REBOOT,
+            Self::Halt => icons::POWEROFF,
+        }
+    }
+
+    /// Returns the [`crate::fl!`] for the variant using this format: `fl!("power-menu-{kebab-case}")`
+    pub fn fl(&self) -> String {
+        match self {
+            Self::Poweroff => fl!("power-menu-poweroff"),
+            Self::Reboot => fl!("power-menu-reboot"),
+            Self::Halt => fl!("power-menu-halt"),
+        }
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -56,5 +56,11 @@ macro_rules! fl {
 
 /// Lowercase the first letter of the string.
 pub(crate) fn lowercase_first_char(string: &str) -> String {
-    string[0..1].to_lowercase() + &string[1..]
+    let mut chars = string.chars();
+    let Some(uppercase) = chars.next() else {
+        return "".into();
+    };
+
+    let lowercase = uppercase.to_lowercase().to_string();
+    lowercase + chars.collect::<String>().as_str()
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 max-ishere <47008271+max-ishere@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! # Internationalization
+//!
+//! Firstly Initialize the language selection with [`init`]. Then use the [`fl`] macro to request a string by id.
+
+use std::sync::LazyLock;
+
+use i18n_embed::{
+    fluent::{fluent_language_loader, FluentLanguageLoader},
+    DefaultLocalizer, LanguageLoader as _, Localizer,
+};
+use rust_embed::RustEmbed;
+use unic_langid::LanguageIdentifier;
+
+#[derive(RustEmbed)]
+#[folder = "i18n"]
+struct Localizations;
+
+/// Applies the requested language(s) to be used when calling the `fl!()` macro.
+pub fn init(requested_languages: &[LanguageIdentifier]) {
+    if let Err(err) = localizer().select(requested_languages) {
+        eprintln!("error while loading fluent localizations: {err}");
+    }
+}
+
+/// Get the `Localizer` to be used for localizing this library.
+#[must_use]
+fn localizer() -> Box<dyn Localizer> {
+    Box::from(DefaultLocalizer::new(&*LANGUAGE_LOADER, &Localizations))
+}
+
+pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
+    let loader: FluentLanguageLoader = fluent_language_loader!();
+
+    loader
+        .load_fallback_language(&Localizations)
+        .expect("Error while loading fallback language");
+
+    loader
+});
+
+/// Request a localized string by ID.
+#[macro_export]
+macro_rules! fl {
+    ($message_id:literal) => {{
+        i18n_embed_fl::fl!($crate::i18n::LANGUAGE_LOADER, $message_id)
+    }};
+
+    ($message_id:literal, $($args:expr),*) => {{
+        i18n_embed_fl::fl!($crate::i18n::LANGUAGE_LOADER, $message_id, $($args), *)
+    }};
+}
+
+/// Lowercase the first letter of the string.
+pub(crate) fn lowercase_first_char(string: &str) -> String {
+    string[0..1].to_lowercase() + &string[1..]
+}

--- a/src/tomlutils.rs
+++ b/src/tomlutils.rs
@@ -17,16 +17,16 @@ pub enum TomlFileError {
     IO(#[from] std::io::Error),
     #[error("Error decoding UTF-8")]
     Utf8(#[from] std::str::Utf8Error),
-    #[error("Error decoding TOML file contents")]
+    #[error("Error decoding TOML file contents: {0}")]
     TomlDecode(#[from] toml::de::Error),
-    #[error("Error encoding into TOML")]
+    #[error("Error encoding into TOML: {0}")]
     TomlEncode(#[from] toml::ser::Error),
 }
 
 pub type TomlFileResult<T> = Result<T, TomlFileError>;
 
 /// Load the TOML file from disk without any checks.
-fn load_raw_toml<T: DeserializeOwned>(path: &Path) -> TomlFileResult<T> {
+pub(crate) fn load_raw_toml<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> TomlFileResult<T> {
     Ok(toml::from_str(std::str::from_utf8(
         read(path)?.as_slice(),
     )?)?)


### PR DESCRIPTION
This PR is not complete yet, but I wanted to get some feedback if the overall direction is right.

I taught ReGreet how to interact with systemd and the linux `shutdown` command. Coming up is support for arbitrary commands (blocker for merging this). I don't have any more time this weekend to work on this so I'll just leave this draft until I finish the last feature.

There's also i18n support added. Currently, only the power menu is translated, with 2 languages (the ones I know): English & Ukrainian. Going through the entire repo and replacing all the strings is rather time-consuming so I won't be doing that just yet.

To test out the different languages, run this:

```sh
LANG=uk cargo run -- --demo
```

The screenshots are available in #108.