### PR TITLE
feat: add the *GTK* `cursor_blink` option, to optionally disable cursor blinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These screenshots use the [Canta GTK theme](https://github.com/vinceliuice/Canta
     - Dark mode
     - Icon theme
     - Cursor theme
+    - Cursor blink on/off
     - Font
 * Allows changing reboot & poweroff commands for different init systems
 * Supports custom CSS files for further customizations
@@ -211,6 +212,7 @@ Currently, the following can be configured:
 * Dark mode
 * Icon theme
 * Cursor theme
+* Cursor blink on/off
 * Font
 * Reboot command
 * Shut down command

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -23,6 +23,9 @@ application_prefer_dark_theme = true
 # Cursor theme name
 cursor_theme_name = "Adwaita"
 
+# Whether to blink the cursor
+cursor_blink = true
+
 # Font name and size
 font_name = "Cantarell 16"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,10 @@ impl Default for AppearanceSettings {
     }
 }
 
+fn yes() -> bool {
+    true
+}
+
 /// Struct holding all supported GTK settings
 #[derive(Default, Deserialize, Serialize)]
 pub struct GtkSettings {
@@ -34,6 +38,8 @@ pub struct GtkSettings {
     pub application_prefer_dark_theme: bool,
     #[serde(default)]
     pub cursor_theme_name: Option<String>,
+    #[serde(default = "yes")]
+    pub cursor_blink: bool,
     #[serde(default)]
     pub font_name: Option<String>,
     #[serde(default)]

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -41,6 +41,9 @@ fn setup_settings(model: &Greeter, root: &gtk::ApplicationWindow) {
         settings.set_gtk_cursor_theme_name(config.cursor_theme_name.as_deref());
     };
 
+    debug!("Setting cursor blink: {}", config.cursor_blink);
+    settings.set_gtk_cursor_blink(config.cursor_blink);
+
     if let Some(font) = &config.font_name {
         debug!("Setting font: {font}");
         settings.set_gtk_font_name(config.font_name.as_deref());


### PR DESCRIPTION
Would really appreciate this option. As a *Neovim* user, I'm really used a cursor that doesn't blink. I'm sure lots of *Neovim* users feel the same.

I tested this. By default it does nothing new. It disables cursor blinking with:

```ini
[GTK]
cursor_blink = false
```

Closes #125.