### PR TITLE
add gtk4 pango markup support for clock widget

### DIFF
--- a/src/gui/widget/clock.rs
+++ b/src/gui/widget/clock.rs
@@ -119,9 +119,10 @@ impl Component for Clock {
     view! {
         gtk::Label {
             set_width_request: label_width.min(i32::MAX as u32) as i32,
+            set_justify: gtk::Justification::Center,
 
             #[watch]
-            set_text: &model.current_time
+            set_markup: &model.current_time
         }
     }
 


### PR DESCRIPTION
hey.

adding support for Pango markup language in clock widget:
https://docs.gtk.org/gtk4/method.Label.set_markup.html

i am using if for something like that in the `regreet.toml`:
```
format = "<span font='SF Pr Display Bold 52'>%A</span>\n<span font='SF Pr Display Bold 25'>%d %B</span>\n<span font='SF Pr Display Bold 12'>- %H:%M -</span>"
```
to get the possibility to adapt the look of ReGreet to the hyprlock theme `Style-10` of https://github.com/MrVivekRajan/Hyprlock-Styles

<img width="450" height="219" alt="2025-09-27-21-44-15" src="https://github.com/user-attachments/assets/0781ee82-e6c1-4b8c-aa01-428db2332c6d" />
