### PR TITLE
replace jiff by chrono. add support for localization of date and time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,8 +318,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "pure-rust-locales",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1068,7 +1093,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1109,47 +1134,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
 
 [[package]]
 name = "js-sys"
@@ -1201,6 +1185,16 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "localzone"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718530aa7b3842752f82224791ea1db5e6b7260513b8ab45706937dbf54f7b4d"
+dependencies = [
+ "js-sys",
+ "windows",
+]
 
 [[package]]
 name = "lock_api"
@@ -1357,6 +1351,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,21 +1435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1488,21 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
@@ -1490,6 +1537,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "regreet"
 version = "0.3.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "clap",
  "const_format",
  "educe",
@@ -1498,7 +1547,7 @@ dependencies = [
  "greetd_ipc",
  "gtk4",
  "humantime-serde",
- "jiff",
+ "localzone",
  "lru",
  "regex",
  "relm4",
@@ -1690,6 +1739,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2212,6 +2267,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,7 +2295,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -2254,6 +2329,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
@@ -2278,6 +2362,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,23 +327,33 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -1192,6 +1202,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718530aa7b3842752f82224791ea1db5e6b7260513b8ab45706937dbf54f7b4d"
 dependencies = [
+ "chrono-tz 0.9.0",
  "js-sys",
  "windows",
 ]
@@ -1365,7 +1376,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -1375,7 +1395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -1384,7 +1404,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand",
 ]
 
@@ -1393,6 +1413,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1538,7 +1567,7 @@ name = "regreet"
 version = "0.3.0"
 dependencies = [
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.10.4",
  "clap",
  "const_format",
  "educe",
@@ -1553,6 +1582,7 @@ dependencies = [
  "relm4",
  "serde",
  "shlex",
+ "sys-locale",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
@@ -1798,6 +1828,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,23 +366,33 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -1557,6 +1567,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718530aa7b3842752f82224791ea1db5e6b7260513b8ab45706937dbf54f7b4d"
 dependencies = [
+ "chrono-tz 0.9.0",
  "js-sys",
  "windows",
 ]
@@ -1775,7 +1786,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -1785,7 +1805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -1794,7 +1814,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand",
 ]
 
@@ -1803,6 +1823,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1989,7 +2018,7 @@ name = "regreet"
 version = "0.4.0"
 dependencies = [
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.10.4",
  "clap",
  "const_format",
  "educe",
@@ -2006,6 +2035,7 @@ dependencies = [
  "relm4",
  "serde",
  "shlex",
+ "sys-locale",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
@@ -2276,6 +2306,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,8 +357,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "pure-rust-locales",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1348,7 +1373,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1397,12 +1422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
- "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
 ]
 
 [[package]]
@@ -1414,21 +1437,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
 ]
 
 [[package]]
@@ -1542,6 +1550,16 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "localzone"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718530aa7b3842752f82224791ea1db5e6b7260513b8ab45706937dbf54f7b4d"
+dependencies = [
+ "js-sys",
+ "windows",
+]
 
 [[package]]
 name = "lock_api"
@@ -1737,10 +1755,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1829,6 +1894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +1919,21 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -1902,6 +1988,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "regreet"
 version = "0.4.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "clap",
  "const_format",
  "educe",
@@ -1912,7 +2000,7 @@ dependencies = [
  "greetd_ipc",
  "gtk4",
  "humantime-serde",
- "jiff",
+ "localzone",
  "lru",
  "regex",
  "relm4",
@@ -2123,6 +2211,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2665,6 +2759,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2787,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -2707,6 +2821,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
@@ -2731,6 +2854,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ gtk4_8 = ["gtk4/v4_8"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["unstable-locales"] }
-chrono-tz = "0.8"
+chrono-tz = "0.10.4"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2.33"
 educe = "0.6"
@@ -27,12 +27,13 @@ glob = "0.3"
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = "0.10"
 humantime-serde = "1.1.1"
+localzone = { version = "0.3.1", features = ["auto_validation"] }
 lru = "0.18"
-localzone = "0.3.1"
 regex = "1.10"
 relm4 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 shlex = "1.3"
+sys-locale = "0.3.2"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["net", "time"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ license = "GPL-3.0-or-later"
 gtk4_8 = ["gtk4/v4_8"]
 
 [dependencies]
+chrono = { version = "0.4", features = ["unstable-locales"] }
+chrono-tz = "0.8"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2.33"
 educe = "0.6"
@@ -25,8 +27,8 @@ glob = "0.3"
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = "0.10"
 humantime-serde = "1.1.1"
-jiff = "0.2.24"
 lru = "0.18"
+localzone = "0.3.1"
 regex = "1.10"
 relm4 = "0.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 chrono = { version = "0.4", features = ["unstable-locales"] }
-chrono-tz = "0.8"
+chrono-tz = "0.10.4"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2.33"
 educe = "0.6"
@@ -26,12 +26,13 @@ glycin = { version = "3.0.8", features = ["gdk4", "tokio"] } # This depends on G
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = { version = "0.10", features = ["v4_8"] }
 humantime-serde = "1.1.1"
+localzone = { version = "0.3.1", features = ["auto_validation"] }
 lru = "0.18"
-localzone = "0.3.1"
 regex = "1.10"
 relm4 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 shlex = "1.3"
+sys-locale = "0.3.2"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["fs", "net", "time"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ license = "GPL-3.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4", features = ["unstable-locales"] }
+chrono-tz = "0.8"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2.33"
 educe = "0.6"
@@ -24,8 +26,8 @@ glycin = { version = "3.0.8", features = ["gdk4", "tokio"] } # This depends on G
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = { version = "0.10", features = ["v4_8"] }
 humantime-serde = "1.1.1"
-jiff = "0.2.24"
 lru = "0.18"
+localzone = "0.3.1"
 regex = "1.10"
 relm4 = "0.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -52,7 +52,7 @@ greeting_msg = "Welcome back!"
 
 [widget.clock]
 # strftime format argument
-# See https://docs.rs/jiff/0.1.14/jiff/fmt/strtime/index.html#conversion-specifications
+# See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 format = "%a %H:%M"
 
 # How often to update the text
@@ -65,3 +65,8 @@ timezone = "America/Chicago"
 # Ask GTK to make the label at least this wide. This helps keeps the parent element layout and width consistent.
 # Experiment with different widths, the interpretation of this value is entirely up to GTK.
 label_width = 150
+
+# Locale setting for displaying the clock's time format and language.
+# This controls the language and regional format used for time-related elements like AM/PM symbols, 
+# month and weekday names, and number formatting.
+locale = "en_US"

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -51,7 +51,7 @@ greeting_msg = "Welcome back!"
 
 
 [widget.clock]
-# strftime format argument
+# Clock date & time format
 # See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 format = "%a %H:%M"
 
@@ -66,7 +66,8 @@ timezone = "America/Chicago"
 # Experiment with different widths, the interpretation of this value is entirely up to GTK.
 label_width = 150
 
-# Locale setting for displaying the clock's time format and language.
-# This controls the language and regional format used for time-related elements like AM/PM symbols, 
+# Locale setting for the clock's date & time format and language
+# This controls the language and regional format used for time-related elements like AM/PM symbols,
 # month and weekday names, and number formatting.
+# Remove to use the system locale.
 locale = "en_US"

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -54,7 +54,7 @@ greeting_msg = "Welcome back!"
 
 
 [widget.clock]
-# strftime format argument
+# Clock date & time format
 # See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 format = "%a %H:%M"
 
@@ -69,7 +69,8 @@ timezone = "America/Chicago"
 # Experiment with different widths, the interpretation of this value is entirely up to GTK.
 label_width = 150
 
-# Locale setting for displaying the clock's time format and language.
-# This controls the language and regional format used for time-related elements like AM/PM symbols, 
+# Locale setting for the clock's date & time format and language
+# This controls the language and regional format used for time-related elements like AM/PM symbols,
 # month and weekday names, and number formatting.
+# Remove to use the system locale.
 locale = "en_US"

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -55,7 +55,7 @@ greeting_msg = "Welcome back!"
 
 [widget.clock]
 # strftime format argument
-# See https://docs.rs/jiff/0.1.14/jiff/fmt/strtime/index.html#conversion-specifications
+# See https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 format = "%a %H:%M"
 
 # How often to update the text
@@ -68,3 +68,8 @@ timezone = "America/Chicago"
 # Ask GTK to make the label at least this wide. This helps keeps the parent element layout and width consistent.
 # Experiment with different widths, the interpretation of this value is entirely up to GTK.
 label_width = 150
+
+# Locale setting for displaying the clock's time format and language.
+# This controls the language and regional format used for time-related elements like AM/PM symbols, 
+# month and weekday names, and number formatting.
+locale = "en_US"

--- a/src/gui/widget/clock.rs
+++ b/src/gui/widget/clock.rs
@@ -6,7 +6,12 @@
 
 use std::time::Duration;
 
-use jiff::{Timestamp, Zoned, fmt::strtime::format, tz::TimeZone};
+use chrono::{Locale, Utc};
+use chrono_tz::Tz;
+use localzone;
+
+use std::fmt;
+
 use relm4::{gtk::prelude::*, prelude::*};
 use serde::{
     Deserialize, Deserializer,
@@ -18,7 +23,7 @@ use tokio::time::sleep;
 pub struct ClockConfig {
     /// A [strftime][fmt] argument
     ///
-    /// [fmt]: jiff::fmt::strtime
+    /// https://docs.rs/chrono/latest/chrono/format/strftime/index.html
     #[serde(alias = "fmt", default = "weekday_and_24h_time")]
     pub format: String,
 
@@ -34,11 +39,15 @@ pub struct ClockConfig {
     /// A timezone from the [IANA Time Zone Database](https://en.wikipedia.org/wiki/Tz_database). If the ID is invalid
     /// or [`None`], uses the system timezone.
     #[serde(alias = "tz", deserialize_with = "parse_tz", default = "system_tz")]
-    pub timezone: TimeZone,
+    pub timezone: Tz,
 
     /// Ask GTK to make the label this wide. This way as the text changes, the label's size can stay static.
     #[serde(default)]
     pub label_width: u32,
+
+    /// The locale to use for time formatting (e.g. "en_US")
+    #[serde(deserialize_with = "locale_deserializer", default)]
+    pub locale: Locale,
 }
 
 fn weekday_and_24h_time() -> String {
@@ -49,12 +58,16 @@ const fn half_second() -> Duration {
     Duration::from_millis(500)
 }
 
-fn system_tz() -> TimeZone {
-    TimeZone::system()
+fn system_tz() -> Tz {
+    chrono_tz::UTC
 }
 
 const fn label_width() -> u32 {
     150
+}
+
+const fn locale() -> Locale {
+    Locale::en_US
 }
 
 impl Default for ClockConfig {
@@ -64,19 +77,21 @@ impl Default for ClockConfig {
             resolution: half_second(),
             timezone: system_tz(),
             label_width: label_width(),
+            locale: locale(),
         }
     }
 }
 
-fn parse_tz<'de, D>(data: D) -> Result<TimeZone, D::Error>
+fn parse_tz<'de, D>(data: D) -> Result<Tz, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct TimeZoneVisitor;
-    impl Visitor<'_> for TimeZoneVisitor {
-        type Value = TimeZone;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    impl Visitor<'_> for TimeZoneVisitor {
+        type Value = Tz;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a string containing an IANA Time Zone name")
         }
 
@@ -84,20 +99,67 @@ where
         where
             E: de::Error,
         {
-            Ok(TimeZone::get(time_zone_name).unwrap_or_else(|e| {
-                error!("Invalid timezone '{time_zone_name}' in the config: {e}");
-                TimeZone::system()
-            }))
+            // Try parsing the provided time zone string
+            time_zone_name.parse::<Tz>().or_else(|_e| {
+                // Fallback: try to get the system's IANA timezone via localzone
+                if let Some(sys_tz_name) = localzone::get_local_zone() {
+                    sys_tz_name.parse::<Tz>().map_err(|parse_err| {
+                        E::custom(format!(
+                            "provided TZ '{}' invalid, system TZ '{}' invalid too: {}",
+                            time_zone_name, sys_tz_name, parse_err
+                        ))
+                    })
+                } else {
+                    match localzone::get_local_zone() {
+                        Some(tz_name) => info!("Local system timezone: {}", tz_name),
+                        None => info!("Could not determine system timezone"),
+                    }
+                    // Final fallback: UTC
+                    Ok(chrono_tz::UTC)
+                }
+            })
         }
     }
 
     data.deserialize_any(TimeZoneVisitor)
 }
 
+fn locale_deserializer<'de, D>(deserializer: D) -> Result<Locale, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct LocaleVisitor;
+
+    impl Visitor<'_> for LocaleVisitor {
+        type Value = Locale;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string representing a locale (e.g., 'en_US')")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            // Attempt to parse the value into a Locale
+            match value.parse::<Locale>() {
+                Ok(locale) => Ok(locale),
+                Err(_) => {
+                    // If parsing fails, handle it gracefully by providing a custom error
+                    Err(E::custom(format!("Invalid locale string: '{}'", value)))
+                }
+            }
+        }
+    }
+
+    deserializer.deserialize_str(LocaleVisitor)
+}
+
 #[derive(Debug)]
 pub struct Clock {
     format: String,
-    timezone: TimeZone,
+    timezone: Tz,
+    locale: Locale,
 
     current_time: String,
 }
@@ -132,6 +194,7 @@ impl Component for Clock {
             resolution,
             timezone,
             label_width,
+            locale,
         }: Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
@@ -154,6 +217,7 @@ impl Component for Clock {
             current_time: String::new(),
             format,
             timezone,
+            locale,
         };
 
         let widgets = view_output!();
@@ -162,13 +226,8 @@ impl Component for Clock {
     }
 
     fn update_cmd(&mut self, Tick: Self::CommandOutput, _: ComponentSender<Self>, _: &Self::Root) {
-        let now = Zoned::new(Timestamp::now(), self.timezone.clone());
-
-        let text = match jiff::fmt::strtime::format(&self.format, &now) {
-            Ok(str) => str,
-            Err(_) => format(weekday_and_24h_time(), &now)
-                .unwrap_or_else(|_| "Time formatting error.".into()),
-        };
+        let now = Utc::now().with_timezone(&self.timezone);
+        let text = now.format_localized(&self.format, self.locale).to_string();
 
         self.current_time = text;
     }

--- a/src/gui/widget/clock.rs
+++ b/src/gui/widget/clock.rs
@@ -4,13 +4,11 @@
 
 //! A [serde-configurable][`ClockConfig`] clock label widget.
 
+use std::fmt;
 use std::time::Duration;
 
 use chrono::{Locale, Utc};
 use chrono_tz::Tz;
-use localzone;
-
-use std::fmt;
 
 use relm4::{gtk::prelude::*, prelude::*};
 use serde::{
@@ -46,7 +44,7 @@ pub struct ClockConfig {
     pub label_width: u32,
 
     /// The locale to use for time formatting (e.g. "en_US")
-    #[serde(deserialize_with = "locale_deserializer", default)]
+    #[serde(deserialize_with = "parse_locale", default = "system_locale")]
     pub locale: Locale,
 }
 
@@ -59,15 +57,33 @@ const fn half_second() -> Duration {
 }
 
 fn system_tz() -> Tz {
-    chrono_tz::UTC
+    if let Some(tz_name) = localzone::get_local_zone() {
+        debug!("Local system timezone: {tz_name}");
+        tz_name.parse().unwrap_or_else(|e| {
+            warn!("Could not parse system timezone {tz_name}: {e}");
+            chrono_tz::UTC
+        })
+    } else {
+        warn!("Could not determine system timezone");
+        chrono_tz::UTC
+    }
 }
 
 const fn label_width() -> u32 {
     150
 }
 
-const fn locale() -> Locale {
-    Locale::en_US
+fn system_locale() -> Locale {
+    if let Some(locale) = sys_locale::get_locale() {
+        debug!("Local system timezone: {locale}");
+        locale.parse::<Locale>().unwrap_or_else(|_| {
+            warn!("Could not parse system locale {locale}");
+            Locale::en_US
+        })
+    } else {
+        warn!("Could not determine system locale");
+        Locale::en_US
+    }
 }
 
 impl Default for ClockConfig {
@@ -77,7 +93,7 @@ impl Default for ClockConfig {
             resolution: half_second(),
             timezone: system_tz(),
             label_width: label_width(),
-            locale: locale(),
+            locale: system_locale(),
         }
     }
 }
@@ -99,24 +115,9 @@ where
         where
             E: de::Error,
         {
-            // Try parsing the provided time zone string
-            time_zone_name.parse::<Tz>().or_else(|_e| {
-                // Fallback: try to get the system's IANA timezone via localzone
-                if let Some(sys_tz_name) = localzone::get_local_zone() {
-                    sys_tz_name.parse::<Tz>().map_err(|parse_err| {
-                        E::custom(format!(
-                            "provided TZ '{}' invalid, system TZ '{}' invalid too: {}",
-                            time_zone_name, sys_tz_name, parse_err
-                        ))
-                    })
-                } else {
-                    match localzone::get_local_zone() {
-                        Some(tz_name) => info!("Local system timezone: {}", tz_name),
-                        None => info!("Could not determine system timezone"),
-                    }
-                    // Final fallback: UTC
-                    Ok(chrono_tz::UTC)
-                }
+            time_zone_name.parse::<Tz>().or_else(|e| {
+                error!("Invalid timezone '{time_zone_name}' in the config: {e}");
+                Ok(system_tz())
             })
         }
     }
@@ -124,7 +125,7 @@ where
     data.deserialize_any(TimeZoneVisitor)
 }
 
-fn locale_deserializer<'de, D>(deserializer: D) -> Result<Locale, D::Error>
+fn parse_locale<'de, D>(data: D) -> Result<Locale, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -137,22 +138,18 @@ where
             formatter.write_str("a string representing a locale (e.g., 'en_US')")
         }
 
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        fn visit_str<E>(self, locale_name: &str) -> Result<Self::Value, E>
         where
             E: de::Error,
         {
-            // Attempt to parse the value into a Locale
-            match value.parse::<Locale>() {
-                Ok(locale) => Ok(locale),
-                Err(_) => {
-                    // If parsing fails, handle it gracefully by providing a custom error
-                    Err(E::custom(format!("Invalid locale string: '{}'", value)))
-                }
-            }
+            locale_name.parse::<Locale>().or_else(|_| {
+                error!("Invalid locale '{locale_name}' in the config");
+                Ok(system_locale())
+            })
         }
     }
 
-    deserializer.deserialize_str(LocaleVisitor)
+    data.deserialize_str(LocaleVisitor)
 }
 
 #[derive(Debug)]
@@ -160,7 +157,6 @@ pub struct Clock {
     format: String,
     timezone: Tz,
     locale: Locale,
-
     current_time: String,
 }
 
@@ -227,6 +223,7 @@ impl Component for Clock {
 
     fn update_cmd(&mut self, Tick: Self::CommandOutput, _: ComponentSender<Self>, _: &Self::Root) {
         let now = Utc::now().with_timezone(&self.timezone);
+
         let text = now.format_localized(&self.format, self.locale).to_string();
 
         self.current_time = text;

--- a/src/gui/widget/clock.rs
+++ b/src/gui/widget/clock.rs
@@ -6,7 +6,12 @@
 
 use std::time::Duration;
 
-use jiff::{Timestamp, Zoned, fmt::strtime::format, tz::TimeZone};
+use chrono::{Locale, Utc};
+use chrono_tz::Tz;
+use localzone;
+
+use std::fmt;
+
 use relm4::{gtk::prelude::*, prelude::*};
 use serde::{
     Deserialize, Deserializer,
@@ -18,7 +23,7 @@ use tokio::time::sleep;
 pub struct ClockConfig {
     /// A [strftime][fmt] argument
     ///
-    /// [fmt]: jiff::fmt::strtime
+    /// https://docs.rs/chrono/latest/chrono/format/strftime/index.html
     #[serde(alias = "fmt", default = "weekday_and_24h_time")]
     pub format: String,
 
@@ -34,11 +39,15 @@ pub struct ClockConfig {
     /// A timezone from the [IANA Time Zone Database](https://en.wikipedia.org/wiki/Tz_database). If the ID is invalid
     /// or [`None`], uses the system timezone.
     #[serde(alias = "tz", deserialize_with = "parse_tz", default = "system_tz")]
-    pub timezone: TimeZone,
+    pub timezone: Tz,
 
     /// Ask GTK to make the label this wide. This way as the text changes, the label's size can stay static.
     #[serde(default = "label_width")]
     pub label_width: u32,
+
+    /// The locale to use for time formatting (e.g. "en_US")
+    #[serde(deserialize_with = "locale_deserializer", default)]
+    pub locale: Locale,
 }
 
 fn weekday_and_24h_time() -> String {
@@ -49,12 +58,16 @@ const fn half_second() -> Duration {
     Duration::from_millis(500)
 }
 
-fn system_tz() -> TimeZone {
-    TimeZone::system()
+fn system_tz() -> Tz {
+    chrono_tz::UTC
 }
 
 const fn label_width() -> u32 {
     150
+}
+
+const fn locale() -> Locale {
+    Locale::en_US
 }
 
 impl Default for ClockConfig {
@@ -64,19 +77,21 @@ impl Default for ClockConfig {
             resolution: half_second(),
             timezone: system_tz(),
             label_width: label_width(),
+            locale: locale(),
         }
     }
 }
 
-fn parse_tz<'de, D>(data: D) -> Result<TimeZone, D::Error>
+fn parse_tz<'de, D>(data: D) -> Result<Tz, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct TimeZoneVisitor;
-    impl Visitor<'_> for TimeZoneVisitor {
-        type Value = TimeZone;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    impl Visitor<'_> for TimeZoneVisitor {
+        type Value = Tz;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a string containing an IANA Time Zone name")
         }
 
@@ -84,20 +99,67 @@ where
         where
             E: de::Error,
         {
-            Ok(TimeZone::get(time_zone_name).unwrap_or_else(|e| {
-                error!("Invalid timezone '{time_zone_name}' in the config: {e}");
-                TimeZone::system()
-            }))
+            // Try parsing the provided time zone string
+            time_zone_name.parse::<Tz>().or_else(|_e| {
+                // Fallback: try to get the system's IANA timezone via localzone
+                if let Some(sys_tz_name) = localzone::get_local_zone() {
+                    sys_tz_name.parse::<Tz>().map_err(|parse_err| {
+                        E::custom(format!(
+                            "provided TZ '{}' invalid, system TZ '{}' invalid too: {}",
+                            time_zone_name, sys_tz_name, parse_err
+                        ))
+                    })
+                } else {
+                    match localzone::get_local_zone() {
+                        Some(tz_name) => info!("Local system timezone: {}", tz_name),
+                        None => info!("Could not determine system timezone"),
+                    }
+                    // Final fallback: UTC
+                    Ok(chrono_tz::UTC)
+                }
+            })
         }
     }
 
     data.deserialize_any(TimeZoneVisitor)
 }
 
+fn locale_deserializer<'de, D>(deserializer: D) -> Result<Locale, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct LocaleVisitor;
+
+    impl Visitor<'_> for LocaleVisitor {
+        type Value = Locale;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string representing a locale (e.g., 'en_US')")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            // Attempt to parse the value into a Locale
+            match value.parse::<Locale>() {
+                Ok(locale) => Ok(locale),
+                Err(_) => {
+                    // If parsing fails, handle it gracefully by providing a custom error
+                    Err(E::custom(format!("Invalid locale string: '{}'", value)))
+                }
+            }
+        }
+    }
+
+    deserializer.deserialize_str(LocaleVisitor)
+}
+
 #[derive(Debug)]
 pub struct Clock {
     format: String,
-    timezone: TimeZone,
+    timezone: Tz,
+    locale: Locale,
 
     current_time: String,
 }
@@ -132,6 +194,7 @@ impl Component for Clock {
             resolution,
             timezone,
             label_width,
+            locale,
         }: Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
@@ -154,6 +217,7 @@ impl Component for Clock {
             current_time: String::new(),
             format,
             timezone,
+            locale,
         };
 
         let widgets = view_output!();
@@ -162,13 +226,8 @@ impl Component for Clock {
     }
 
     fn update_cmd(&mut self, Tick: Self::CommandOutput, _: ComponentSender<Self>, _: &Self::Root) {
-        let now = Zoned::new(Timestamp::now(), self.timezone.clone());
-
-        let text = match jiff::fmt::strtime::format(&self.format, &now) {
-            Ok(str) => str,
-            Err(_) => format(weekday_and_24h_time(), &now)
-                .unwrap_or_else(|_| "Time formatting error.".into()),
-        };
+        let now = Utc::now().with_timezone(&self.timezone);
+        let text = now.format_localized(&self.format, self.locale).to_string();
 
         self.current_time = text;
     }


### PR DESCRIPTION
### Summary

Hey. This pull request replaces the `jiff` crate with `chrono`, `chrono-tz`, and `localzone` for handling time formatting, time zones, and locale customization in the clock widget. It introduces support for user-specified locales, improving i18n by allowing time display in different languages and regional formats.

### Motivation

- The jiff crate is still limited for localized time formatting.
- chrono offers a stable API with broad support for date/time formatting using strftime.
- chrono-tz supports IANA time zones directly.
- The localzone crate enables automatic detection of the system's time zone.
- Added locale customization so the clock widget can adapt to the user’s preferred language/region.

This improves internationalization and configurability of the clock component.

### Changes
#### Dependencies

- Added `chrono` with unstable-locales feature for localized formatting.
- Added `chrono-tz` for IANA timezone parsing.
- Added `localzone` for detecting the system’s local timezone. 
- Removed jiff.

#### Configuration (regreet.sample.toml)

- Updated the documentation link to chrono’s strftime reference.
- Added new locale option, allowing users to specify the locale for formatting:
```
        [widget.clock]
        format = "%a %H:%M"
        timezone = "America/Chicago"
        label_width = 150
        locale = "en_US"
```
- This controls language-specific elements (e.g., month, weekday, AM/PM).

#### Code (widget/clock.rs)

- Replaced jiff::TimeZone and formatting logic with chrono::Utc, chrono_tz::Tz, and localized formatting (format_localized).
- Implemented timezone parsing:
  - User-specified timezone (Tz) is preferred.
  - Falls back to system local timezone via localzone.
  - Defaults to UTC if none found.
- Implemented deserializer for Locale, with validation and fallback behavior.
- Updated ClockConfig to include locale field.
- Updated Clock implementation:
  - Current time is updated using Utc::now().with_timezone(...).
  - Formatted using the configured Locale.

### Benefits

- Improved configurability through locales.
- Consistent formatting with chrono’s  ecosystem.
- Reliable timezone handling with system fallback via localzone.
- Enhanced internationalization support for multilingual deployments.