### PR TITLE
Breaking change in Hyprland v0.52.0 -> Updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ exec-once = regreet; hyprctl dispatch exit
 misc {
     disable_hyprland_logo = true
     disable_splash_rendering = true
-    disable_hyprland_qtutils_check = true
+    disable_hyprland_guiutils_check = true
 }
 ```
 


### PR DESCRIPTION
With respect to the latest release changes of Hyprland (v0.52.0) introducing a breaking change, that is quote on quote:

Breaking changes:

    misc:disable_hyprland_qtutils_check -> misc:disable_hyprland_guiutils_check (hyprland-qtutils is now archived in favor of hyprland-guiutils)
    
This commit updates the README file to adapt to this, so that there is no error thrown.

NOTE: Leaving the instructions as it is doesn't affect any functionality, except for displaying error message
