### PR TITLE
Updated hyprland example for new syntax in 0.53.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ misc {
 Then, set Hyprland to use this config (whose path is shown here as `/path/to/custom/hyprland/config`) as the default greetd session:
 ```toml
 [default_session]
-command = "Hyprland --config /path/to/custom/hyprland/config"
+command = "start-hyprland -- -c /path/to/custom/hyprland/config"
 user = "greeter"
 ```
 


### PR DESCRIPTION
Hyprland example needed updating for 0.53.0 changes to use the new `start-hyprland` syntax. See adjustments here: https://wiki.hypr.land/Getting-Started/Master-Tutorial/#launching-hyprland 

Without this change on regreet start you get a large message about you should not be launching using hyprland unless you are in debug mode.