### PR TITLE
Fetch users and shells from AccountsService using D-Bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +243,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -133,6 +276,28 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bumpalo"
@@ -195,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +460,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,12 +493,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -323,6 +532,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum-ordinalize"
@@ -345,10 +560,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "field-offset"
@@ -391,6 +664,12 @@ dependencies = [
  "nanorand",
  "spin",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -451,6 +730,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -551,6 +843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +863,19 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -784,6 +1099,9 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -793,7 +1111,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -801,6 +1119,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -842,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +1185,7 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -921,10 +1258,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -992,7 +1341,20 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1044,6 +1406,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,16 +1458,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1110,22 +1532,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "pwd"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c71c0c79b9701efe4e1e4b563b2016dd4ee789eb99badcb09d61ac4b92e4a2"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1172,7 +1620,6 @@ dependencies = [
  "jiff",
  "lazy_static",
  "lru",
- "pwd",
  "regex",
  "relm4",
  "serde",
@@ -1185,6 +1632,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracker",
+ "zbus",
 ]
 
 [[package]]
@@ -1234,6 +1682,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1287,12 +1748,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1309,6 +1792,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1345,6 +1838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1878,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "test-case"
@@ -1636,6 +2148,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,10 +2195,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1726,6 +2279,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +2320,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1750,6 +2343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1823,4 +2425,221 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,13 +1618,11 @@ dependencies = [
  "gtk4",
  "humantime-serde",
  "jiff",
- "lazy_static",
  "lru",
  "regex",
  "relm4",
  "serde",
  "shlex",
- "test-case",
  "thiserror 2.0.9",
  "tokio",
  "toml",
@@ -1890,39 +1888,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ humantime-serde = "1.1.1"
 jiff = "0.1.14"
 lazy_static = "1.5.0"
 lru = "0.16"
-pwd = "1.4.0"
 regex = "1.10"
 relm4 = "0.9"
 serde = { version = "1.0", features = ["derive"] }
@@ -37,6 +36,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["local-time"] }
 tracker = "0.2"
+zbus = { version = "4.4.0", features = ["async-io"], no-default-features = true }
 
 [features]
 gtk4_8 = ["gtk4/v4_8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = "0.9"
 humantime-serde = "1.1.1"
 jiff = "0.1.14"
-lazy_static = "1.5.0"
 lru = "0.16"
 regex = "1.10"
 relm4 = "0.9"
@@ -36,10 +35,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["local-time"] }
 tracker = "0.2"
-zbus = { version = "4.4.0", features = ["async-io"], no-default-features = true }
+zbus = { version = "4.4.0", features = ["async-io"], default-features = false }
 
 [features]
 gtk4_8 = ["gtk4/v4_8"]
-
-[dev-dependencies]
-test-case = "3.3.1"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -47,45 +47,6 @@ pub const POWEROFF_CMD: &str = env_or!("POWEROFF_CMD", "poweroff");
 /// Default greeting message
 pub const GREETING_MSG: &str = "Welcome back!";
 
-/// `:`-separated search path for `login.defs` file.
-///
-/// By default this file is at `/etc/login.defs`, however some distros (e.g. Tumbleweed) move it to other locations.
-///
-/// See: <https://github.com/rharish101/ReGreet/issues/89>
-pub const LOGIN_DEFS_PATHS: &[&str] = {
-    const ENV: &str = env_or!("LOGIN_DEFS_PATHS", "/etc/login.defs:/usr/etc/login.defs");
-    &str_split!(ENV, ':')
-};
-
-lazy_static! {
-    /// Override the default `UID_MIN` in `login.defs`. If the string cannot be parsed at runtime, the value is `1_000`.
-    ///
-    /// This is not meant as a configuration facility. Only override this value if it's a different default in the
-    /// `passwd` suite.
-    pub static ref LOGIN_DEFS_UID_MIN: u64 = {
-        const DEFAULT: u64 = 1_000;
-        const ENV: &str = env_or!("LOGIN_DEFS_UID_MIN", formatcp!("{DEFAULT}"));
-
-        ENV.parse()
-            .map_err(|e| error!("Failed to parse LOGIN_DEFS_UID_MIN='{ENV}': {e}. This is a compile time mistake!"))
-            .unwrap_or(DEFAULT)
-    };
-
-    /// Override the default `UID_MAX` in `login.defs`. If the string cannot be parsed at runtime, the value is
-    /// `60_000`.
-    ///
-    /// This is not meant as a configuration facility. Only override this value if it's a different default in the
-    /// `passwd` suite.
-    pub static ref LOGIN_DEFS_UID_MAX: u64 = {
-        const DEFAULT: u64 = 60_000;
-        const ENV: &str = env_or!("LOGIN_DEFS_UID_MAX", formatcp!("{DEFAULT}"));
-
-        ENV.parse()
-            .map_err(|e| error!("Failed to parse LOGIN_DEFS_UID_MAX='{ENV}': {e}. This is a compile time mistake!"))
-            .unwrap_or(DEFAULT)
-    };
-}
-
 /// Directories separated by `:`, containing desktop files for X11/Wayland sessions
 pub const SESSION_DIRS: &str = env_or!(
     "SESSION_DIRS",

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -518,7 +518,7 @@ impl Greeter {
                 (
                     None,
                     Some(SessionInfo {
-                        command: cmd.clone(),
+                        command: vec![cmd.clone()],
                         sess_type: SessionType::Unknown,
                     }),
                 )

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -127,7 +127,9 @@ impl Greeter {
 
         Self {
             greetd_client,
-            sys_util: SysUtil::new(&config).expect("Couldn't read available users and sessions"),
+            sys_util: SysUtil::new(&config)
+                .await
+                .expect("Couldn't read available users and sessions"),
             cache: Cache::new(),
             sess_info: None,
             config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,7 @@ use crate::gui::{Greeter, GreeterInit};
 #[macro_use]
 extern crate tracing;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate const_format;
-
-#[cfg(test)]
-#[macro_use]
-extern crate test_case;
 
 const MAX_LOG_FILES: usize = 3;
 const MAX_LOG_SIZE: usize = 1024 * 1024;

--- a/src/sysutil.rs
+++ b/src/sysutil.rs
@@ -57,20 +57,29 @@ pub struct SysUtil {
 
 impl SysUtil {
     pub async fn new(config: &Config) -> Result<Self, Box<dyn Error>> {
-        let conn = Connection::system().await?;
-        let accounts_proxy = AccountsServiceProxy::new(&conn).await?;
+        let dbus_system_conn = Connection::system().await?;
+        let accounts_proxy = AccountsServiceProxy::new(&dbus_system_conn).await?;
 
         let mut user_proxies = Vec::new();
         for user_path in accounts_proxy.list_cached_users().await? {
-            let user_proxy = UserProxy::builder(&conn).path(user_path)?.build().await?;
+            let user_proxy = UserProxy::builder(&dbus_system_conn)
+                .path(user_path)?
+                .build()
+                .await?;
+
             user_proxies.push(user_proxy);
         }
 
         let mut usernames = HashMap::new();
 
         for user_proxy in &user_proxies {
-            let real_name = user_proxy.real_name().await?;
+            let mut real_name = user_proxy.real_name().await?;
             let user_name = user_proxy.user_name().await?;
+
+            // If real name is not set, just use the username instead
+            if real_name.is_empty() {
+                real_name.clone_from(&user_name);
+            }
 
             usernames.insert(real_name, user_name);
         }

--- a/src/sysutil.rs
+++ b/src/sysutil.rs
@@ -42,7 +42,7 @@ pub struct SessionInfo {
 
 // Convenient aliases for used maps
 type UserMap = HashMap<String, String>;
-type ShellMap = HashMap<String, Vec<String>>;
+type ShellMap = HashMap<String, String>;
 type SessionMap = HashMap<String, SessionInfo>;
 
 /// Stores info of all regular users and sessions
@@ -81,7 +81,7 @@ impl SysUtil {
             let user_name = user_proxy.user_name().await?;
             let shell = user_proxy.shell().await?;
 
-            shells.insert(user_name, vec![shell]);
+            shells.insert(user_name, shell);
         }
 
         Ok(Self {

--- a/src/sysutil.rs
+++ b/src/sysutil.rs
@@ -4,21 +4,25 @@
 
 //! Helper for system utilities like users and sessions
 
+mod accounts_service;
+
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::fs::{read, read_to_string};
+use std::error::Error;
+use std::fs::read;
 use std::io;
-use std::ops::ControlFlow;
 use std::path::Path;
 use std::str::from_utf8;
 
 use glob::glob;
-use pwd::Passwd;
 use regex::Regex;
 use shlex::Shlex;
+use zbus::Connection;
 
+use self::accounts_service::AccountsServiceProxy;
+use self::accounts_service::UserProxy;
 use crate::config::Config;
-use crate::constants::{LOGIN_DEFS_PATHS, LOGIN_DEFS_UID_MAX, LOGIN_DEFS_UID_MIN, SESSION_DIRS};
+use crate::constants::SESSION_DIRS;
 
 /// XDG data directory variable name (parent directory for X11/Wayland sessions)
 const XDG_DIR_ENV_VAR: &str = "XDG_DATA_DIRS";
@@ -52,85 +56,39 @@ pub struct SysUtil {
 }
 
 impl SysUtil {
-    pub fn new(config: &Config) -> io::Result<Self> {
-        let path = (*LOGIN_DEFS_PATHS).iter().try_for_each(|path| {
-            if let Ok(true) = AsRef::<Path>::as_ref(&path).try_exists() {
-                ControlFlow::Break(path)
-            } else {
-                ControlFlow::Continue(())
-            }
-        });
+    pub async fn new(config: &Config) -> Result<Self, Box<dyn Error>> {
+        let conn = Connection::system().await?;
+        let accounts_proxy = AccountsServiceProxy::new(&conn).await?;
 
-        let normal_user = match path {
-            ControlFlow::Break(path) => read_to_string(path)
-                .map_err(|err| {
-                    warn!("Failed to read login.defs from '{path}', using default values: {err}")
-                })
-                .map(|text| NormalUser::parse_login_defs(&text))
-                .unwrap_or_default(),
-            ControlFlow::Continue(()) => {
-                warn!("`login.defs` file not found in these paths: {LOGIN_DEFS_PATHS:?}",);
+        let mut user_proxies = Vec::new();
+        for user_path in accounts_proxy.list_cached_users().await? {
+            let user_proxy = UserProxy::builder(&conn).path(user_path)?.build().await?;
+            user_proxies.push(user_proxy);
+        }
 
-                NormalUser::default()
-            }
-        };
+        let mut usernames = HashMap::new();
 
-        debug!("{normal_user:?}");
+        for user_proxy in &user_proxies {
+            let real_name = user_proxy.real_name().await?;
+            let user_name = user_proxy.user_name().await?;
 
-        let (users, shells) = Self::init_users(normal_user)?;
+            usernames.insert(real_name, user_name);
+        }
+
+        let mut shells = HashMap::new();
+
+        for user_proxy in &user_proxies {
+            let user_name = user_proxy.user_name().await?;
+            let shell = user_proxy.shell().await?;
+
+            shells.insert(user_name, vec![shell]);
+        }
+
         Ok(Self {
-            users,
+            users: usernames,
             shells,
             sessions: Self::init_sessions(config)?,
         })
-    }
-
-    /// Get the list of regular users.
-    ///
-    /// These are defined as a list of users with UID between `UID_MIN` and `UID_MAX`.
-    fn init_users(normal_user: NormalUser) -> io::Result<(UserMap, ShellMap)> {
-        let mut users = HashMap::new();
-        let mut shells = HashMap::new();
-
-        for entry in Passwd::iter().filter(|entry| normal_user.is_normal_user(entry.uid)) {
-            // Use the actual system username if the "full name" is not available.
-            let full_name = if let Some(gecos) = entry.gecos {
-                if gecos.is_empty() {
-                    debug!(
-                        "Found user '{}' with UID '{}' and empty full name",
-                        entry.name, entry.uid
-                    );
-                    entry.name.clone()
-                } else {
-                    // Only take first entry in gecos field.
-                    let gecos_name_part: &str = gecos.split(',').next().unwrap_or(&gecos);
-                    debug!(
-                        "Found user '{}' with UID '{}' and full name: {gecos_name_part}",
-                        entry.name, entry.uid
-                    );
-                    gecos_name_part.into()
-                }
-            } else {
-                debug!(
-                    "Found user '{}' with UID '{}' and missing full name",
-                    entry.name, entry.uid
-                );
-                entry.name.clone()
-            };
-            users.insert(full_name, entry.name.clone());
-
-            if let Some(cmd) = shlex::split(entry.shell.as_str()) {
-                shells.insert(entry.name, cmd);
-            } else {
-                // Skip this user, since a missing command means that we can't use it.
-                warn!(
-                    "Couldn't split shell of username '{}' into arguments: {}",
-                    entry.name, entry.shell
-                );
-            };
-        }
-
-        Ok((users, shells))
     }
 
     /// Get available X11 and Wayland sessions.
@@ -340,161 +298,5 @@ impl SysUtil {
     /// If the full name is not available, the filename stem is used.
     pub fn get_sessions(&self) -> &SessionMap {
         &self.sessions
-    }
-}
-
-/// A named tuple of min and max that stores UID limits for normal users.
-///
-/// Use [`Self::parse_login_defs`] to obtain the system configuration. If the file is missing or there are
-/// parsing errors a fallback of [`Self::default`] should be used.
-#[derive(Debug, PartialEq, Eq)]
-struct NormalUser {
-    uid_min: u64,
-    uid_max: u64,
-}
-
-impl Default for NormalUser {
-    fn default() -> Self {
-        Self {
-            uid_min: *LOGIN_DEFS_UID_MIN,
-            uid_max: *LOGIN_DEFS_UID_MAX,
-        }
-    }
-}
-
-impl NormalUser {
-    /// Parses the `login.defs` file content and looks for `UID_MIN` and `UID_MAX` definitions. If a definition is
-    /// missing or causes parsing errors, the default values [`struct@LOGIN_DEFS_UID_MIN`] and
-    /// [`struct@LOGIN_DEFS_UID_MAX`] are used.
-    ///
-    /// This parser is highly specific to parsing the 2 required values, thus it focuses on doing the least amout of
-    /// compute required to extracting them.
-    ///
-    /// Errors are dropped because they are unlikely and their handling would result in the use of default values
-    /// anyway.
-    pub fn parse_login_defs(text: &str) -> Self {
-        let mut min = None;
-        let mut max = None;
-
-        for line in text.lines().map(str::trim) {
-            const KEY_LENGTH: usize = "UID_XXX".len();
-
-            // At MSRV 1.80 you could use `split_at_checked`, this is just a way to not raise it.
-            // This checks if the string is of sufficient length too.
-            if !line.is_char_boundary(KEY_LENGTH) {
-                continue;
-            }
-            let (key, val) = line.split_at(KEY_LENGTH);
-
-            if !val.starts_with(char::is_whitespace) {
-                continue;
-            }
-
-            match (key, min, max) {
-                ("UID_MIN", None, _) => min = Self::parse_number(val),
-                ("UID_MAX", _, None) => max = Self::parse_number(val),
-                _ => continue,
-            }
-
-            if min.is_some() && max.is_some() {
-                break;
-            }
-        }
-
-        Self {
-            uid_min: min.unwrap_or(*LOGIN_DEFS_UID_MIN),
-            uid_max: max.unwrap_or(*LOGIN_DEFS_UID_MAX),
-        }
-    }
-
-    /// Parses a number value in a `/etc/login.defs` entry. As per the manpage:
-    ///
-    /// - `0x` prefix: hex number
-    /// - `0` prefix: octal number
-    /// - starts with `1..9`: decimal number
-    ///
-    /// In case the string value is not parsable as a number the entry value is considered invalid and `None` is
-    /// returned.
-    fn parse_number(num: &str) -> Option<u64> {
-        let num = num.trim();
-        if num == "0" {
-            return Some(0);
-        }
-
-        if let Some(octal) = num.strip_prefix('0') {
-            if let Some(hex) = octal.strip_prefix('x') {
-                return u64::from_str_radix(hex, 16).ok();
-            }
-
-            return u64::from_str_radix(octal, 8).ok();
-        }
-
-        num.parse().ok()
-    }
-
-    // Returns true for regular users, false for those outside the UID limit, eg. git or root.
-    pub fn is_normal_user<T>(&self, uid: T) -> bool
-    where
-        T: Into<u64>,
-    {
-        (self.uid_min..=self.uid_max).contains(&uid.into())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[allow(non_snake_case)]
-    mod UidLimit {
-        use super::super::*;
-
-        #[test_case(
-            &["UID_MIN 1", "UID_MAX 10"].join("\n")
-            => NormalUser { uid_min: 1, uid_max: 10 };
-            "both configured"
-        )]
-        #[test_case(
-            &["UID_MAX 10", "UID_MIN 1"].join("\n")
-            => NormalUser { uid_min: 1, uid_max: 10 };
-            "reverse order"
-        )]
-        #[test_case(
-            &["OTHER 20",
-            "# Comment",
-            "",
-            "UID_MAX 10",
-            "UID_MIN 1",
-            "MORE_TEXT 40"].join("\n")
-            => NormalUser { uid_min: 1, uid_max: 10 };
-            "complex file"
-        )]
-        #[test_case(
-            "UID_MAX10"
-            => NormalUser::default();
-            "no space"
-        )]
-        #[test_case(
-            "SUB_UID_MAX 10"
-            => NormalUser::default();
-            "invalid field (with prefix)"
-        )]
-        #[test_case(
-            "UID_MAX_BLAH 10"
-            => NormalUser::default();
-            "invalid field (with suffix)"
-        )]
-        fn parse_login_defs(text: &str) -> NormalUser {
-            NormalUser::parse_login_defs(text)
-        }
-
-        #[test_case("" => None; "empty")]
-        #[test_case("no" => None; "string")]
-        #[test_case("0" => Some(0); "zero")]
-        #[test_case("0x" => None; "0x isn't a hex number")]
-        #[test_case("10" => Some(10); "decimal")]
-        #[test_case("0777" => Some(0o777); "octal")]
-        #[test_case("0xDeadBeef" => Some(0xdead_beef); "hex")]
-        fn parse_number(num: &str) -> Option<u64> {
-            NormalUser::parse_number(num)
-        }
     }
 }

--- a/src/sysutil/accounts_service.rs
+++ b/src/sysutil/accounts_service.rs
@@ -1,0 +1,27 @@
+use zbus::{proxy, zvariant::OwnedObjectPath};
+
+#[proxy(
+    default_path = "/org/freedesktop/Accounts",
+    default_service = "org.freedesktop.Accounts",
+    interface = "org.freedesktop.Accounts"
+)]
+trait AccountsService {
+    /// Returns an array of [`User`] paths.
+    fn list_cached_users(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}
+
+#[proxy(
+    default_service = "org.freedesktop.Accounts",
+    default_path = "/org/freedesktop/Accounts",
+    interface = "org.freedesktop.Accounts.User"
+)]
+trait User {
+    #[zbus(property)]
+    fn user_name(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn real_name(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn shell(&self) -> zbus::Result<String>;
+}

--- a/src/sysutil/accounts_service.rs
+++ b/src/sysutil/accounts_service.rs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2022 Harish Rajagopal <harish.rajagopals@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Barebones D-Bus interface for the org.freedesktop.Accounts D-Bus service.
+
 use zbus::{proxy, zvariant::OwnedObjectPath};
 
 #[proxy(


### PR DESCRIPTION
This PR removes the old `getpwent()` related code with manual login.defs UID filtering and replaces it with the [AccountsService API](https://www.freedesktop.org/wiki/Software/AccountsService/) that most other display managers and DEs use.

This fixes #152 as accounts can now be hidden by creating a `/var/lib/AccountsService/users/<username>` file with
```
[User]
SystemAccount=true
```

I believe pretty much any modern Linux desktop PC has the AccountsService service but if necessary, I can bring the old code back as a runtime fallback or a cargo feature (though I really like how much relying purely on AccountsService cleaned up the code). 

PR suggestions/improvements are very welcome! 
(Especially considering this was my first time using the zbus crate).

Thanks!