### PR TITLE
feat: add login_box_opacity config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 target/
 packaging/output/
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: 0BSD
 
 target/
+packaging/output/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ file-rotate = "0.8"
 glob = "0.3"
 greetd_ipc = { version = "0.10", features = ["tokio-codec"] }
 gtk4 = "0.10"
+gtk4-layer-shell = "0.7.1"
 humantime-serde = "1.1.1"
 jiff = "0.2.24"
 lru = "0.18"

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -56,6 +56,8 @@ RUN VERSION=$(grep '^version' /build/regreet/Cargo.toml | sed 's/.*"\(.*\)".*/\1
     --depends gtk4 \
     --depends glib2 \
     --depends gdk-pixbuf2 \
+    --depends gstreamer1 \
+    --depends gstreamer1-plugins-good \
     -C /staging \
     --prefix / \
     usr/local/bin/regreet && \

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -1,0 +1,62 @@
+# ── Stage 1: base ─────────────────────────────────────────────────────────────
+# Rust toolchain + fpm. Heavy and stable — only changes if toolchain shifts.
+FROM fedora:43 AS base
+
+RUN dnf install -y \
+    # Rust toolchain
+    rust cargo \
+    # Build essentials
+    pkg-config \
+    # fpm packaging
+    ruby ruby-devel rpm-build \
+    && dnf clean all
+
+RUN gem install fpm --no-document
+
+# ── Stage 2: extras ───────────────────────────────────────────────────────────
+# GTK4 ecosystem dev libs. Add here when cargo reports a missing C library.
+FROM base AS extras
+
+RUN dnf install -y \
+    # GTK4 and core deps
+    gtk4-devel \
+    glib2-devel \
+    gdk-pixbuf2-devel \
+    # Pango / Cairo (text rendering)
+    pango-devel \
+    cairo-devel \
+    cairo-gobject-devel \
+    # Graphene (GTK4 geometry)
+    graphene-devel \
+    # GObject introspection (needed by gtk4-rs build scripts)
+    gobject-introspection-devel \
+    && dnf clean all
+
+# ── Stage 3: builder ──────────────────────────────────────────────────────────
+# Builds from the local fork source — no external clone needed.
+FROM extras AS builder
+
+COPY . /build/regreet
+
+RUN cd /build/regreet && \
+    cargo build --release && \
+    install -Dm755 target/release/regreet /staging/usr/local/bin/regreet
+
+# ── RPM packaging ─────────────────────────────────────────────────────────────
+RUN VERSION=$(grep '^version' /build/regreet/Cargo.toml | sed 's/.*"\(.*\)".*/\1/') && \
+    mkdir -p /output && \
+    cd /output && \
+    fpm -s dir -t rpm \
+    --name regreet \
+    --version "$VERSION" \
+    --iteration 1 \
+    --description "ReGreet - clean GTK4 greeter for greetd" \
+    --url "https://github.com/jkinum/ReGreet" \
+    --license "GPL-3.0" \
+    --depends gtk4 \
+    --depends glib2 \
+    --depends gdk-pixbuf2 \
+    -C /staging \
+    --prefix / \
+    usr/local/bin/regreet && \
+    ls -lh /output/*.rpm

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -30,6 +30,8 @@ RUN dnf install -y \
     graphene-devel \
     # GObject introspection (needed by gtk4-rs build scripts)
     gobject-introspection-devel \
+    # wlr-layer-shell support for GTK4 (multi-output greeter)
+    gtk4-layer-shell-devel \
     && dnf clean all
 
 # ── Stage 3: builder ──────────────────────────────────────────────────────────
@@ -54,6 +56,7 @@ RUN VERSION=$(grep '^version' /build/regreet/Cargo.toml | sed 's/.*"\(.*\)".*/\1
     --url "https://github.com/jkinum/ReGreet" \
     --license "GPL-3.0" \
     --depends gtk4 \
+    --depends gtk4-layer-shell \
     --depends glib2 \
     --depends gdk-pixbuf2 \
     --depends gstreamer1 \

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -1,6 +1,6 @@
 # ── Stage 1: base ─────────────────────────────────────────────────────────────
 # Rust toolchain + fpm. Heavy and stable — only changes if toolchain shifts.
-FROM fedora:43 AS base
+FROM fedora:44 AS base
 
 RUN dnf install -y \
     # Rust toolchain
@@ -51,7 +51,7 @@ RUN VERSION=$(grep '^version' /build/regreet/Cargo.toml | sed 's/.*"\(.*\)".*/\1
     fpm -s dir -t rpm \
     --name regreet \
     --version "$VERSION" \
-    --iteration 1 \
+    --iteration 2 \
     --description "ReGreet - clean GTK4 greeter for greetd" \
     --url "https://github.com/jkinum/ReGreet" \
     --license "GPL-3.0" \

--- a/packaging/build-and-install.sh
+++ b/packaging/build-and-install.sh
@@ -35,6 +35,10 @@ sudo dnf install -y greetd greetd-selinux cage
 echo "==> Installing ReGreet RPM..."
 sudo rpm -Uvh --force "$RPM"
 
+echo "==> Installing systemd-tmpfiles config (log/state dirs for greetd user)..."
+sudo cp "$REPO_ROOT/systemd-tmpfiles.conf" /etc/tmpfiles.d/regreet.conf
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/regreet.conf
+
 echo ""
 echo "==> Done. Next steps:"
 echo "    1. Configure greetd:  sudo cp $SCRIPT_DIR/config/greetd.toml /etc/greetd/config.toml"

--- a/packaging/build-and-install.sh
+++ b/packaging/build-and-install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE="localhost/regreet-builder:latest"
+OUTPUT_DIR="$SCRIPT_DIR/output"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "==> Building regreet image (first run ~10-15 minutes for cargo deps)..."
+podman build \
+    --network=host \
+    --pull=missing \
+    --tag "$IMAGE" \
+    --file "$SCRIPT_DIR/Containerfile" \
+    "$REPO_ROOT"
+
+echo "==> Extracting RPM from container..."
+podman run --rm \
+    -v "$OUTPUT_DIR:/out:z" \
+    "$IMAGE" \
+    bash -c 'cp /output/*.rpm /out/'
+
+RPM=$(ls -t "$OUTPUT_DIR"/regreet*.rpm 2>/dev/null | head -1)
+if [[ -z "$RPM" ]]; then
+    echo "ERROR: No RPM found in $OUTPUT_DIR"
+    exit 1
+fi
+echo "==> Built: $RPM"
+
+echo "==> Installing greetd and cage from Fedora repos..."
+sudo dnf install -y greetd greetd-selinux cage
+
+echo "==> Installing ReGreet RPM..."
+sudo rpm -Uvh --force "$RPM"
+
+echo ""
+echo "==> Done. Next steps:"
+echo "    1. Configure greetd:  sudo cp $SCRIPT_DIR/config/greetd.toml /etc/greetd/config.toml"
+echo "    2. Configure regreet: sudo cp $SCRIPT_DIR/config/regreet.toml /etc/greetd/regreet.toml"
+echo "    3. Install theme CSS: sudo cp $SCRIPT_DIR/config/regreet.css /etc/greetd/regreet.css"
+echo "    4. Copy wallpaper:    sudo cp ~/Pictures/wallpapers/<file> /usr/share/greetd/wallpaper.png"
+echo "                          sudo chmod 644 /usr/share/greetd/wallpaper.png"
+echo "    5. Test before switching: sudo systemctl start greetd (on a free VT)"
+echo "    6. sudo systemctl disable sddm && sudo systemctl enable greetd"

--- a/packaging/build-and-install.sh
+++ b/packaging/build-and-install.sh
@@ -9,7 +9,10 @@ OUTPUT_DIR="$SCRIPT_DIR/output"
 mkdir -p "$OUTPUT_DIR"
 
 echo "==> Building regreet image (first run ~10-15 minutes for cargo deps)..."
-podman build \
+# Rootful: rootless podman on Fedora 43 fails to chown cups-filesystem (a hard dep
+# of gtk4) during rpm unpack. Build + extract under sudo so the throwaway builder
+# image installs cleanly; production containers stay rootless.
+sudo podman build \
     --network=host \
     --pull=missing \
     --tag "$IMAGE" \
@@ -17,7 +20,7 @@ podman build \
     "$REPO_ROOT"
 
 echo "==> Extracting RPM from container..."
-podman run --rm \
+sudo podman run --rm \
     -v "$OUTPUT_DIR:/out:z" \
     "$IMAGE" \
     bash -c 'cp /output/*.rpm /out/'

--- a/packaging/build-and-install.sh
+++ b/packaging/build-and-install.sh
@@ -6,8 +6,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 IMAGE="localhost/regreet-builder:latest"
 OUTPUT_DIR="$SCRIPT_DIR/output"
 
+DO_BUILD=1
+DO_INSTALL=1
+case "${1:-}" in
+    --build-only)   DO_INSTALL=0 ;;
+    --install-only) DO_BUILD=0 ;;
+    "")             ;;
+    *) echo "usage: $0 [--build-only|--install-only]" >&2; exit 2 ;;
+esac
+
 mkdir -p "$OUTPUT_DIR"
 
+if (( DO_BUILD )); then
 echo "==> Building regreet image (first run ~10-15 minutes for cargo deps)..."
 # Rootful: rootless podman on Fedora 43 fails to chown cups-filesystem (a hard dep
 # of gtk4) during rpm unpack. Build + extract under sudo so the throwaway builder
@@ -24,6 +34,7 @@ sudo podman run --rm \
     -v "$OUTPUT_DIR:/out:z" \
     "$IMAGE" \
     bash -c 'cp /output/*.rpm /out/'
+fi
 
 RPM=$(ls -t "$OUTPUT_DIR"/regreet*.rpm 2>/dev/null | head -1)
 if [[ -z "$RPM" ]]; then
@@ -31,6 +42,11 @@ if [[ -z "$RPM" ]]; then
     exit 1
 fi
 echo "==> Built: $RPM"
+
+if (( ! DO_INSTALL )); then
+    echo "==> --build-only: stopping before install."
+    exit 0
+fi
 
 echo "==> Installing greetd and cage from Fedora repos..."
 sudo dnf install -y greetd greetd-selinux cage

--- a/packaging/config/greetd.toml
+++ b/packaging/config/greetd.toml
@@ -1,0 +1,6 @@
+[terminal]
+vt = 1
+
+[default_session]
+command = "cage -s -- regreet"
+user = "greetd"

--- a/packaging/config/regreet.css
+++ b/packaging/config/regreet.css
@@ -1,0 +1,93 @@
+/* Hyprland/wallust palette — regreet login screen */
+
+window {
+    background-color: transparent;
+    color: #FDF8FE;
+    font-family: "JetBrainsMono Nerd Font", monospace;
+    font-size: 14px;
+}
+
+/* Login box: grid is the actual background surface */
+frame.background grid {
+    background-color: rgba(10, 5, 20, 0.60);
+    border-radius: 8px;
+}
+
+/* Frame provides border + glow only */
+frame.background {
+    border: 2px solid rgba(125, 74, 180, 0.75);
+    border-radius: 10px;
+    box-shadow: 0 0 30px rgba(125, 74, 180, 0.45),
+                0 4px 48px rgba(0, 0, 0, 0.6);
+}
+
+label {
+    color: #FDF8FE;
+    font-family: "JetBrainsMono Nerd Font", monospace;
+}
+
+entry,
+passwordentry {
+    background-color: rgba(5, 2, 12, 0.70);
+    color: #FDF8FE;
+    border: 1px solid rgba(125, 74, 180, 0.65);
+    border-radius: 8px;
+    padding: 4px 8px;
+    caret-color: #9A5BDD;
+}
+
+entry:focus,
+passwordentry:focus {
+    border-color: #9A5BDD;
+    box-shadow: 0 0 0 2px rgba(154, 91, 221, 0.25);
+}
+
+combobox,
+comboboxtext {
+    background-color: rgba(5, 2, 12, 0.70);
+    color: #FDF8FE;
+    border: 1px solid rgba(125, 74, 180, 0.65);
+    border-radius: 8px;
+}
+
+button {
+    background-color: rgba(30, 15, 50, 0.55);
+    color: #FDF8FE;
+    border: 1px solid rgba(125, 74, 180, 0.55);
+    border-radius: 8px;
+    padding: 4px 12px;
+}
+
+button:hover {
+    background-color: rgba(125, 74, 180, 0.30);
+    border-color: #9A5BDD;
+    box-shadow: 0 0 8px rgba(154, 91, 221, 0.35);
+}
+
+button.suggested-action {
+    background-color: rgba(125, 74, 180, 0.55);
+    border-color: #9A5BDD;
+}
+
+button.suggested-action:hover {
+    background-color: rgba(154, 91, 221, 0.70);
+    box-shadow: 0 0 12px rgba(154, 91, 221, 0.45);
+}
+
+button.destructive-action {
+    background-color: rgba(30, 5, 15, 0.60);
+    color: #ff7a93;
+    border-color: rgba(255, 122, 147, 0.50);
+}
+
+button.destructive-action:hover {
+    background-color: rgba(255, 122, 147, 0.18);
+    box-shadow: 0 0 8px rgba(255, 122, 147, 0.30);
+}
+
+infobar {
+    background-color: rgba(40, 5, 15, 0.85);
+    border: 1px solid #ff7a93;
+    border-radius: 8px;
+    color: #ff7a93;
+}

--- a/packaging/config/regreet.toml
+++ b/packaging/config/regreet.toml
@@ -4,6 +4,7 @@
 # sudo chmod 644 /usr/share/greetd/wallpaper.png
 path = "/usr/share/greetd/wallpaper.png"
 fit = "Cover"
+login_box_opacity = 0.82
 
 [GTK]
 application_prefer_dark_theme = true

--- a/packaging/config/regreet.toml
+++ b/packaging/config/regreet.toml
@@ -2,16 +2,21 @@
 # Set to any wallpaper from ~/Pictures/wallpapers/ — must be readable by greeter user
 # sudo cp ~/Pictures/wallpapers/<file> /usr/share/greetd/wallpaper.png
 # sudo chmod 644 /usr/share/greetd/wallpaper.png
-path = "/usr/share/greetd/wallpaper.png"
-fit = "Cover"
+path = \"/usr/share/greetd/wallpaper.png\"
+fit = \"Cover\"
 login_box_opacity = 0.82
 
 [GTK]
 application_prefer_dark_theme = true
-icon_theme_name = "Adwaita"
-cursor_theme_name = "Adwaita"
-css_file = "/etc/greetd/regreet.css"
+icon_theme_name = \"Adwaita\"
+cursor_theme_name = \"Adwaita\"
+font_name = \"JetBrainsMono Nerd Font Medium 11\"
+css_file = \"/etc/greetd/regreet.css\"
 
 [commands]
-reboot = ["systemctl", "reboot"]
-poweroff = ["systemctl", "poweroff"]
+reboot = [\"systemctl\", \"reboot\"]
+poweroff = [\"systemctl\", \"poweroff\"]
+
+[widget.clock]
+format = \"%A %B %-d  %I:%M %p\"
+label_width = 380

--- a/packaging/config/regreet.toml
+++ b/packaging/config/regreet.toml
@@ -1,0 +1,16 @@
+[background]
+# Set to any wallpaper from ~/Pictures/wallpapers/ — must be readable by greeter user
+# sudo cp ~/Pictures/wallpapers/<file> /usr/share/greetd/wallpaper.png
+# sudo chmod 644 /usr/share/greetd/wallpaper.png
+path = "/usr/share/greetd/wallpaper.png"
+fit = "Cover"
+
+[GTK]
+application_prefer_dark_theme = true
+icon_theme_name = "Adwaita"
+cursor_theme_name = "Adwaita"
+css_file = "/etc/greetd/regreet.css"
+
+[commands]
+reboot = ["systemctl", "reboot"]
+poweroff = ["systemctl", "poweroff"]

--- a/packaging/config/regreet.toml
+++ b/packaging/config/regreet.toml
@@ -2,21 +2,21 @@
 # Set to any wallpaper from ~/Pictures/wallpapers/ — must be readable by greeter user
 # sudo cp ~/Pictures/wallpapers/<file> /usr/share/greetd/wallpaper.png
 # sudo chmod 644 /usr/share/greetd/wallpaper.png
-path = \"/usr/share/greetd/wallpaper.png\"
-fit = \"Cover\"
+path = "/usr/share/greetd/wallpaper.webm"
+fit = "Cover"
 login_box_opacity = 0.82
 
 [GTK]
 application_prefer_dark_theme = true
-icon_theme_name = \"Adwaita\"
-cursor_theme_name = \"Adwaita\"
-font_name = \"JetBrainsMono Nerd Font Medium 11\"
-css_file = \"/etc/greetd/regreet.css\"
+icon_theme_name = "Adwaita"
+cursor_theme_name = "Adwaita"
+font_name = "JetBrainsMono Nerd Font Medium 11"
+css_file = "/etc/greetd/regreet.css"
 
 [commands]
-reboot = [\"systemctl\", \"reboot\"]
-poweroff = [\"systemctl\", \"poweroff\"]
+reboot = ["systemctl", "reboot"]
+poweroff = ["systemctl", "poweroff"]
 
 [widget.clock]
-format = \"%A %B %-d  %I:%M %p\"
+format = "%A %B %-d  %I:%M %p"
 label_width = 380

--- a/packaging/config/regreet.toml
+++ b/packaging/config/regreet.toml
@@ -17,6 +17,13 @@ css_file = "/etc/greetd/regreet.css"
 reboot = ["systemctl", "reboot"]
 poweroff = ["systemctl", "poweroff"]
 
+[monitors]
+# The login box appears on the first entry that is currently connected, walking down
+# as outputs disappear (lid close = eDP removed). Matched as a substring against the
+# monitor's GDK description ("make model serial (connector)") or connector name:
+# laptop by connector (stable); externals by EDID serial (dock ports shuffle names).
+primary = ["eDP-1", "85103651NA", "85103652NA"]
+
 [widget.clock]
 format = "%A %B %-d  %I:%M %p"
 label_width = 380

--- a/regreet.sample.toml
+++ b/regreet.sample.toml
@@ -12,6 +12,12 @@ path = "/usr/share/backgrounds/greeter.jpg"
 # NOTE: This is ignored if ReGreet isn't compiled with GTK v4.8 support.
 fit = "Contain"
 
+# Opacity of the login box (0.0 = fully transparent, 1.0 = fully opaque)
+# Allows the wallpaper to show through the login box. Default is 1.0 (opaque).
+# NOTE: CSS `opacity` on the frame widget is not respected by GTK4 at the theme
+# rendering level; this option applies opacity via the GTK widget API instead.
+login_box_opacity = 1.0
+
 # The entries defined in this section will be passed to the session as environment variables when it is started
 [env]
 ENV_VARIABLE = "value"

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,4 +181,13 @@ impl Config {
     pub fn get_login_box_opacity(&self) -> f64 {
         self.background.login_box_opacity
     }
+
+    pub fn get_background_is_video(&self) -> bool {
+        self.background.path.as_deref().is_some_and(|p| {
+            matches!(
+                std::path::Path::new(p).extension().and_then(|e| e.to_str()),
+                Some("mp4" | "webm" | "mkv" | "mov" | "avi")
+            )
+        })
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,13 +58,29 @@ pub enum BgFit {
     ScaleDown,
 }
 
+fn default_login_box_opacity() -> f64 {
+    1.0
+}
+
 /// Struct for info about the background image
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 struct Background {
     #[serde(default)]
     path: Option<String>,
     #[serde(default)]
     fit: BgFit,
+    #[serde(default = "default_login_box_opacity")]
+    login_box_opacity: f64,
+}
+
+impl Default for Background {
+    fn default() -> Self {
+        Background {
+            path: None,
+            fit: BgFit::default(),
+            login_box_opacity: default_login_box_opacity(),
+        }
+    }
 }
 
 /// Struct for various system commands
@@ -160,5 +176,9 @@ impl Config {
 
     pub fn get_default_message(&self) -> String {
         self.appearance.greeting_msg.clone()
+    }
+
+    pub fn get_login_box_opacity(&self) -> f64 {
+        self.background.login_box_opacity
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,17 @@ impl Default for Background {
     }
 }
 
+/// Struct for choosing which monitor the login box appears on
+#[derive(Default, Deserialize, Serialize)]
+pub struct Monitors {
+    /// Ordered priority list. The login box is placed on the first entry that is currently
+    /// connected. Each string is matched as a substring against the monitor's GDK description
+    /// ("make model serial (connector)") or its connector name. Match the laptop by connector
+    /// (stable) and external monitors by EDID serial (dock ports shuffle connector names).
+    #[serde(default)]
+    pub primary: Vec<String>,
+}
+
 /// Struct for various system commands
 #[derive(Deserialize, Serialize)]
 pub struct SystemCommands {
@@ -139,6 +150,9 @@ pub struct Config {
     commands: SystemCommands,
 
     #[serde(default)]
+    monitors: Monitors,
+
+    #[serde(default)]
     pub(crate) widget: WidgetConfig,
 }
 
@@ -172,6 +186,10 @@ impl Config {
 
     pub fn get_sys_commands(&self) -> &SystemCommands {
         &self.commands
+    }
+
+    pub fn get_primary_monitors(&self) -> &[String] {
+        &self.monitors.primary
     }
 
     pub fn get_default_message(&self) -> String {

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -383,6 +383,11 @@ impl AsyncComponent for Greeter {
             );
         };
 
+        widgets
+            .ui
+            .login_frame
+            .set_opacity(model.config.get_login_box_opacity());
+
         // Set the default behaviour of pressing the Return key to act like the login button.
         root.set_default_widget(Some(&widgets.ui.login_button));
 

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -124,7 +124,7 @@ impl AsyncComponent for Greeter {
             #[template]
             Ui {
                 #[template_child]
-                background { set_filename: model.config.get_background() },
+                background {},
 
                 #[template_child]
                 clock_frame {
@@ -339,6 +339,18 @@ impl AsyncComponent for Greeter {
         // Make the info bar permanently visible, since it was made invisible during init. The
         // actual visuals are controlled by `InfoBar::set_revealed`.
         widgets.ui.error_info.set_visible(true);
+
+        // Set up background: video via GStreamer MediaFile, static image via set_filename.
+        if let Some(path) = model.config.get_background() {
+            if model.config.get_background_is_video() {
+                let media = gtk::MediaFile::for_filename(path);
+                media.set_loop(true);
+                media.play();
+                widgets.ui.background.set_paintable(Some(&media));
+            } else {
+                widgets.ui.background.set_filename(Some(path));
+            }
+        }
 
         // cfg directives don't work inside Relm4 view! macro.
         #[cfg(feature = "gtk4_8")]

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -49,6 +49,61 @@ impl LayerShellRoot for gtk::Window {
     }
 }
 
+/// The monitor's GDK description, e.g. `"NEC Corporation EA275UHD 85103651NA (DVI-I-1)"`.
+///
+/// Read via the GObject "description" property rather than `MonitorExt::description()` — the
+/// typed getter (GDK 4.10) isn't bound by this gtk4-rs version, but the property is present at
+/// runtime. The string carries make, model, EDID serial, and connector, so a single substring
+/// test covers both serial matches (external monitors) and connector matches (the laptop).
+fn monitor_description(monitor: &gtk::gdk::Monitor) -> String {
+    monitor
+        .property_value("description")
+        .get::<Option<String>>()
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+/// Pick the monitor to place the login box on. Walk the configured priority list and return the
+/// first currently-connected monitor whose description contains the entry as a substring. Falls
+/// back to the first monitor if nothing matches or the list is empty, preserving sensible
+/// behaviour for an unconfigured greeter.
+fn select_primary_monitor(
+    display: &gtk::gdk::Display,
+    priority: &[String],
+) -> Option<gtk::gdk::Monitor> {
+    let monitors: Vec<gtk::gdk::Monitor> = display
+        .monitors()
+        .into_iter()
+        .filter_map(|item| {
+            item.ok()
+                .and_then(|object| object.downcast::<gtk::gdk::Monitor>().ok())
+        })
+        .filter(gtk::gdk::Monitor::is_valid)
+        .collect();
+
+    for key in priority {
+        if let Some(monitor) = monitors
+            .iter()
+            .find(|&monitor| monitor_description(monitor).contains(key.as_str()))
+        {
+            return Some(monitor.clone());
+        }
+    }
+
+    monitors.into_iter().next()
+}
+
+/// Pin the layer-shell login window to the configured primary monitor.
+fn apply_primary_monitor(window: &gtk::Window, display: &gtk::gdk::Display, priority: &[String]) {
+    let monitor = select_primary_monitor(display, priority);
+    match &monitor {
+        Some(monitor) => info!("Placing greeter on monitor: {}", monitor_description(monitor)),
+        None => warn!("No monitor available to place the greeter"),
+    }
+    window.set_monitor(monitor.as_ref());
+}
+
 use super::messages::{CommandMsg, InputMsg, UserSessInfo};
 use super::model::{Greeter, InputMode, Updates};
 use super::templates::Ui;
@@ -349,16 +404,6 @@ impl AsyncComponent for Greeter {
         }
     }
 
-    fn post_view() {
-        if model.updates.changed(Updates::monitor()) {
-            if let Some(monitor) = &model.updates.monitor {
-                widgets.window.fullscreen_on_monitor(monitor);
-                // For some reason, the GTK settings are reset when changing monitors, so re-apply them.
-                setup_settings(self, &widgets.window);
-            }
-        }
-    }
-
     /// Initialize the greeter.
     async fn init(
         input: Self::Init,
@@ -402,9 +447,9 @@ impl AsyncComponent for Greeter {
             warn!("Couldn't cancel greetd session: {err}");
         };
 
-        // Monitor selection / fullscreening is handled by the layer-shell surface set up at
-        // the top of `init` (anchored to all edges), so there is no `fullscreen_on_monitor`
-        // call here.
+        // The layer-shell surface (anchored to all edges in the root constructor) fills the
+        // output; placement on the configured primary monitor happens later in `init` via
+        // `apply_primary_monitor`, so there is no `fullscreen_on_monitor` call here.
 
         setup_settings(&model, &root);
         setup_users_sessions(&model, &widgets);
@@ -427,6 +472,19 @@ impl AsyncComponent for Greeter {
 
         // Set the default behaviour of pressing the Return key to act like the login button.
         root.set_default_widget(Some(&widgets.ui.login_button));
+
+        // Pin the layer-shell surface to the configured primary monitor (the layer surface
+        // otherwise lands on whatever output the compositor picks). Re-pin whenever monitors
+        // come or go — a lid open/close shows up as a monitor add/remove — so placement stays
+        // deterministic and follows the priority list down as outputs disappear.
+        let display = WidgetExt::display(&root);
+        let priority = model.config.get_primary_monitors().to_vec();
+        apply_primary_monitor(&root, &display, &priority);
+        let window = root.clone();
+        let display_for_cb = display.clone();
+        display.monitors().connect_items_changed(move |_, _, _, _| {
+            apply_primary_monitor(&window, &display_for_cb, &priority);
+        });
 
         AsyncComponentParts { model, widgets }
     }
@@ -479,9 +537,6 @@ impl AsyncComponent for Greeter {
             Self::CommandOutput::ClearErr => self.updates.set_error(None),
             Self::CommandOutput::HandleGreetdResponse(response) => {
                 self.handle_greetd_response(&sender, response).await
-            }
-            Self::CommandOutput::MonitorRemoved(display_name) => {
-                self.choose_monitor(display_name.as_str(), &sender)
             }
         };
     }

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -14,15 +14,47 @@ use relm4::{
 };
 use tracing::{debug, info, warn};
 
+use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+
 #[cfg(feature = "gtk4_8")]
 use crate::config::BgFit;
+
+/// Build the greeter window as a full-output layer-shell surface.
+///
+/// This runs as the root *constructor* so it executes inside relm4's `init_root` — before
+/// the window is shown. Layer-shell anchors must be set before the surface is realized, and
+/// an AsyncComponent's root is shown *before* `init` runs, so configuring layer-shell in the
+/// `view!` body (which is applied during `init`) is too late: the anchors are ignored and the
+/// surface stays at its default size. Anchoring all four edges stretches it to fill the
+/// output; the compositor applies each output's transform, so it renders upright on rotated
+/// monitors. The overlay layer keeps it above everything; Exclusive keyboard lets it type.
+trait LayerShellRoot {
+    fn new_greeter() -> Self;
+}
+
+impl LayerShellRoot for gtk::Window {
+    fn new_greeter() -> Self {
+        let window = gtk::Window::new();
+        window.init_layer_shell();
+        window.set_layer(Layer::Overlay);
+        window.set_namespace(Some("regreet"));
+        window.set_keyboard_mode(KeyboardMode::Exclusive);
+        for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+            window.set_anchor(edge, true);
+        }
+        // Cover the whole output, ignoring any panel's reserved space (-1). A greeter session
+        // has no panels, but this keeps the surface full-output regardless.
+        window.set_exclusive_zone(-1);
+        window
+    }
+}
 
 use super::messages::{CommandMsg, InputMsg, UserSessInfo};
 use super::model::{Greeter, InputMode, Updates};
 use super::templates::Ui;
 
 /// Load GTK settings from the greeter config.
-fn setup_settings(model: &Greeter, root: &gtk::ApplicationWindow) {
+fn setup_settings(model: &Greeter, root: &gtk::Window) {
     let settings = root.settings();
     let config = if let Some(config) = model.config.get_gtk_settings() {
         config
@@ -116,7 +148,7 @@ impl AsyncComponent for Greeter {
     view! {
         // The `view!` macro needs a proper widget, not a template, as the root.
         #[name = "window"]
-        gtk::ApplicationWindow {
+        gtk::Window::new_greeter() {
             set_visible: true,
 
             // Name the UI widget, otherwise the inner children cannot be accessed by name.
@@ -333,6 +365,7 @@ impl AsyncComponent for Greeter {
         root: Self::Root,
         sender: AsyncComponentSender<Self>,
     ) -> AsyncComponentParts<Self> {
+        // Layer-shell setup is done in the `view!` macro (before the window is realized).
         let mut model = Self::new(&input.config_path, input.demo).await;
         let widgets = view_output!();
 
@@ -369,18 +402,10 @@ impl AsyncComponent for Greeter {
             warn!("Couldn't cancel greetd session: {err}");
         };
 
-        model.choose_monitor(widgets.ui.display().name().as_str(), &sender);
-        if let Some(monitor) = &model.updates.monitor {
-            // The window needs to be manually fullscreened, since the monitor is `None` at widget
-            // init.
-            root.fullscreen_on_monitor(monitor);
-        } else {
-            // Couldn't choose a monitor, so let the compositor choose it for us.
-            root.fullscreen();
-        }
+        // Monitor selection / fullscreening is handled by the layer-shell surface set up at
+        // the top of `init` (anchored to all edges), so there is no `fullscreen_on_monitor`
+        // call here.
 
-        // For some reason, the GTK settings are reset when changing monitors, so apply them after
-        // full-screening.
         setup_settings(&model, &root);
         setup_users_sessions(&model, &widgets);
 

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -67,7 +67,4 @@ pub enum CommandMsg {
     ClearErr,
     /// Handle a response received from greetd
     HandleGreetdResponse(Response),
-    /// Notify the greeter that a monitor was removed.
-    // The Gstring is the name of the display.
-    MonitorRemoved(GString),
 }

--- a/src/gui/model.rs
+++ b/src/gui/model.rs
@@ -11,13 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use greetd_ipc::{AuthMessageType, ErrorType, Response};
-use relm4::{
-    AsyncComponentSender, Component, Controller,
-    gtk::{
-        gdk::{Display, Monitor},
-        prelude::*,
-    },
-};
+use relm4::{AsyncComponentSender, Component, Controller};
 use tokio::{sync::Mutex, time::sleep};
 
 use crate::cache::Cache;
@@ -60,8 +54,6 @@ pub(super) struct Updates {
     pub(super) active_session_id: Option<String>,
     /// Time that is displayed
     pub(super) time: String,
-    /// Monitor where the window is displayed
-    pub(super) monitor: Option<Monitor>,
 }
 
 impl Updates {
@@ -110,7 +102,6 @@ impl Greeter {
             active_session_id: None,
             tracker: 0,
             time: "".to_string(),
-            monitor: None,
         };
         let greetd_client = Arc::new(Mutex::new(
             GreetdClient::new(demo)
@@ -134,45 +125,6 @@ impl Greeter {
             demo,
             clock,
         }
-    }
-
-    /// Make the greeter full screen over the first monitor.
-    #[instrument(skip(self, sender))]
-    pub(super) fn choose_monitor(
-        &mut self,
-        display_name: &str,
-        sender: &AsyncComponentSender<Self>,
-    ) {
-        let display = match Display::open(Some(display_name)) {
-            Some(display) => display,
-            None => {
-                error!("Couldn't get display with name: {display_name}");
-                return;
-            }
-        };
-
-        let mut chosen_monitor = None;
-        for monitor in display
-            .monitors()
-            .into_iter()
-            .filter_map(|item| {
-                item.ok()
-                    .and_then(|object| object.downcast::<Monitor>().ok())
-            })
-            .filter(Monitor::is_valid)
-        {
-            let sender = sender.clone();
-            monitor.connect_invalidate(move |monitor| {
-                let display_name = monitor.display().name();
-                sender.oneshot_command(async move { CommandMsg::MonitorRemoved(display_name) })
-            });
-            if chosen_monitor.is_none() {
-                // Choose the first monitor.
-                chosen_monitor = Some(monitor);
-            }
-        }
-
-        self.updates.set_monitor(chosen_monitor);
     }
 
     /// Run a command and log any errors in a background thread.

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -160,8 +160,6 @@ impl WidgetTemplate for Ui {
                 set_halign: gtk::Align::Center,
                 set_valign: gtk::Align::Start,
 
-                add_css_class: "background",
-
                 // Make it fit cleanly onto the top edge of the screen.
                 inline_css: "
                     border-top-right-radius: 0px;

--- a/src/gui/templates.rs
+++ b/src/gui/templates.rs
@@ -40,6 +40,7 @@ impl WidgetTemplate for Ui {
             gtk::Picture,
 
             /// Main login box
+            #[name = "login_frame"]
             add_overlay = &gtk::Frame {
                 set_halign: gtk::Align::Center,
                 set_valign: gtk::Align::Center,

--- a/systemd-tmpfiles.conf
+++ b/systemd-tmpfiles.conf
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: 0BSD
 
 # Create the log and state directories.
-d /var/log/regreet 0755 greeter greeter - -
-d /var/lib/regreet 0755 greeter greeter - -
+d /var/log/regreet 0755 greetd greetd - -
+d /var/lib/regreet 0755 greetd greetd - -


### PR DESCRIPTION
## Summary

- Adds `login_box_opacity` (float, 0.0–1.0, default `1.0`) to the `[background]` section of `regreet.toml`
- When set below `1.0`, the login box becomes translucent and the wallpaper shows through
- Default of `1.0` preserves existing fully-opaque behaviour — no breaking change

## Why CSS alone can't do this

GTK4 CSS `opacity` on a `GtkFrame` is not respected at the theme rendering level; the frame's background is painted before CSS compositing occurs. `Widget::set_opacity()` in Rust is honoured by GTK4 and achieves the intended effect.

## Implementation

| File | Change |
|------|--------|
| `src/config.rs` | `login_box_opacity: f64` added to `Background` struct; `Config::get_login_box_opacity()` added |
| `src/gui/templates.rs` | Login `GtkFrame` named `login_frame` for direct access |
| `src/gui/component.rs` | `login_frame.set_opacity()` called during init with config value |
| `regreet.sample.toml` | `login_box_opacity` documented with note on why CSS can't do this |

## Example config

```toml
[background]
path = "/usr/share/backgrounds/greeter.jpg"
fit = "Contain"
login_box_opacity = 0.82   # wallpaper visible through login box
```