### PR TITLE
Fix: defer window visibility until initialization completes

### DIFF
--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -455,6 +455,8 @@ impl AsyncComponent for Greeter {
 
         // Set window visible after all the setup is done.
         root.set_visible(true);
+        // Restore the intended initial focus.
+        widgets.ui.login_button.grab_focus();
 
         AsyncComponentParts { model, widgets }
     }

--- a/src/gui/component.rs
+++ b/src/gui/component.rs
@@ -165,8 +165,6 @@ impl AsyncComponent for Greeter {
         // The `view!` macro needs a proper widget, not a template, as the root.
         #[name = "window"]
         gtk::ApplicationWindow {
-            set_visible: true,
-
             // Name the UI widget, otherwise the inner children cannot be accessed by name.
             #[name = "ui"]
             #[template]
@@ -454,6 +452,9 @@ impl AsyncComponent for Greeter {
                 });
             }
         }
+
+        // Set window visible after all the setup is done.
+        root.set_visible(true);
 
         AsyncComponentParts { model, widgets }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,8 @@ fn main() {
     // Keep the guard alive till the end of the function, since logging depends on this.
     let _guard = init_logging(&args.logs, &args.log_level, args.verbose);
 
-    let app = relm4::RelmApp::new(APP_ID);
+    // We will make the app invisible on startup, then make it visible after style loaded and initialized.
+    let app = relm4::RelmApp::new(APP_ID).visible_on_activate(false);
     app.with_args(vec![]).run_async::<Greeter>(GreeterInit {
         config_path: args.config,
         css_path: args.style,


### PR DESCRIPTION
Hi rharish101, thank you for developing such a nice DM! 

ReGreet currently maps its application window before the asynchronous component initialization has completed. This can briefly *expose an unstyled window* before the background and custom CSS are applied.

The fixing is quite straight forward. Disable Relm4's automatic visibility-on-activate behavior and show the window explicitly after initialization. The intented focus on login button is maintained through this bug fix.

Tested with:
- demo mode
- custom CSS
- Hyprland (0.55.4-1) + greetd (0.10.3-2) on Arch Linux (kernel 6.18.38-1-lts)

I just replace the `/usr/bin/regreet` executable and it works well on fresh reboot.

# Demo

|Before|After|
|:--:|:--:|
|<img width="240" height="135" alt="before" src="https://github.com/user-attachments/assets/b77979c9-74ba-4c14-b425-31824df68a83" />|<img width="240" height="135" alt="after" src="https://github.com/user-attachments/assets/2eea2006-a2a6-4ae9-8c36-b5a50c71fc3a" />
|

# Reproduce

Run the following command with the minimal configuration on commit `b9bc613` (main) -> `afff903` (zzh/fix-unstyled-flashing)
```
path/to/regreet --demo \
  --config ./etc/greetd/regreet.toml \
  --style ./etc/greetd/regreet.css \
  --logs /tmp/regreet-demo.log
```

[etc.tar.gz](https://github.com/user-attachments/files/30097898/etc.tar.gz)

